### PR TITLE
Implement index context indicators and tests

### DIFF
--- a/src/pulsar_neuron/lib/data/feeds.py
+++ b/src/pulsar_neuron/lib/data/feeds.py
@@ -8,12 +8,12 @@ Timeframe = Literal["1d", "15m", "5m"]
 
 
 def get_ohlcv(symbol: str, tf: Timeframe, start, end) -> pd.DataFrame:
-    """Stub: to be implemented against your store/Broker later."""
+    """Stub: implement against your DB/API later."""
 
-    raise NotImplementedError("Wire your data source here.")
+    raise NotImplementedError
 
 
 def get_last_n(symbol: str, tf: Timeframe, n: int) -> pd.DataFrame:
-    """Stub fast path."""
+    """Stub: implement a fast path later."""
 
-    raise NotImplementedError("Wire your cache/store here.")
+    raise NotImplementedError

--- a/src/pulsar_neuron/lib/features/indicators.py
+++ b/src/pulsar_neuron/lib/features/indicators.py
@@ -4,10 +4,20 @@ import pandas as pd
 
 
 def sma(series: pd.Series, n: int) -> pd.Series:
+    """
+    Simple moving average with fixed window n.
+    Returns a series aligned to input index.
+    """
+
     return series.rolling(n, min_periods=n).mean()
 
 
 def sma_slope(series: pd.Series, n: int) -> float:
+    """
+    One-step slope: SMA(n)[-1] - SMA(n)[-2].
+    Returns 0.0 if not enough data.
+    """
+
     s = sma(series, n).dropna()
     if len(s) < 2:
         return 0.0
@@ -15,16 +25,24 @@ def sma_slope(series: pd.Series, n: int) -> float:
 
 
 def volume_ratio(vol_series: pd.Series, n: int = 20) -> float:
-    """Current vol vs median of previous n bars."""
+    """
+    Current bar volume vs median of the previous n bars.
+    Fallbacks to 1.0 if not enough history or zero median.
+    """
 
     if len(vol_series) < n + 1:
         return 1.0
-    med = float(vol_series.iloc[-(n + 1) : -1].median())
-    return 1.0 if med == 0 else float(vol_series.iloc[-1] / med)
+    median_prev = float(vol_series.iloc[-(n + 1) : -1].median())
+    if median_prev == 0:
+        return 1.0
+    return float(vol_series.iloc[-1] / median_prev)
 
 
 def vwap_from_bars(df: pd.DataFrame) -> float:
-    """Compute session VWAP from bars with columns [high,low,close,volume]."""
+    """
+    Session VWAP from bars with columns: high, low, close, volume.
+    Returns 0.0 if volume sum is zero or df empty.
+    """
 
     if df.empty:
         return 0.0

--- a/tests/test_features_index_ctx.py
+++ b/tests/test_features_index_ctx.py
@@ -1,37 +1,60 @@
 import pandas as pd
 
-from pulsar_neuron.lib.features.ctx_index import build_ctx_index
+from pulsar_neuron.lib.features.ctx_index import build_ctx_index, get_orb
+from pulsar_neuron.lib.features.indicators import vwap_from_bars, volume_ratio
 
 
 def _mk(ts, o, h, l, c, v):
     return {"ts": ts, "open": o, "high": h, "low": l, "close": c, "volume": v}
 
 
-def test_build_ctx_minimal():
-    dt = pd.to_datetime
+def test_vwap_and_volratio():
+    df = pd.DataFrame(
+        [
+            _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+            _mk("2025-09-29 09:20", 105, 108, 104, 107, 12),
+            _mk("2025-09-29 09:25", 107, 113, 106, 112, 20),
+        ]
+    )
+    df["ts"] = pd.to_datetime(df["ts"])
+    vw = vwap_from_bars(df)
+    assert vw > 0
+    vr = volume_ratio(df["volume"], n=2)  # current vs median of previous 2
+    assert vr > 0
+
+
+def test_orb_ready_and_ctx():
     d1 = pd.DataFrame(
         [
-            _mk(dt("2025-09-26"), 1, 2, 0.5, 1.5, 0),
-            _mk(dt("2025-09-29"), 1, 2, 0.5, 1.6, 0),
+            _mk("2025-09-26", 1, 2, 0.5, 1.5, 0),
+            _mk("2025-09-29", 1, 2, 0.5, 1.6, 0),
         ]
     )
     m15 = pd.DataFrame(
         [
-            _mk(dt("2025-09-29 09:15"), 100, 110, 95, 105, 10),
-            _mk(dt("2025-09-29 09:30"), 106, 112, 104, 111, 15),
+            _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+            _mk("2025-09-29 09:30", 106, 112, 104, 111, 15),
+            _mk("2025-09-29 09:45", 110, 114, 108, 113, 12),
         ]
     )
     m5 = pd.DataFrame(
         [
-            _mk(dt("2025-09-29 09:15"), 100, 110, 95, 105, 10),
-            _mk(dt("2025-09-29 09:20"), 105, 108, 104, 107, 12),
-            _mk(dt("2025-09-29 09:25"), 107, 113, 106, 112, 20),
+            _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+            _mk("2025-09-29 09:20", 105, 108, 104, 107, 12),
+            _mk("2025-09-29 09:25", 107, 113, 106, 112, 20),
+            _mk("2025-09-29 09:30", 112, 115, 110, 114, 18),
         ]
     )
     for df in (d1, m15, m5):
         df["ts"] = pd.to_datetime(df["ts"])
+
+    orb = get_orb(m5)
+    assert orb.ready is True
+    assert orb.high >= orb.low
+
     ctx = build_ctx_index("NIFTY", d1, m15, m5)
     assert ctx.symbol == "NIFTY"
-    assert ctx.price == 112
-    assert ctx.orb.high >= ctx.orb.low
+    assert ctx.price == 114
+    assert ctx.orb.ready is True
     assert ctx.trend_15m.label in ("up", "down", "neutral")
+    assert 0.0 <= ctx.vol_ratio_5m


### PR DESCRIPTION
## Summary
- add deterministic SMA, slope, VWAP, and volume ratio helpers for feature building
- enrich index context structures with ORB handling, daily levels, trends, VWAP distance, and ATR fallback defaults
- cover context builder and indicator helpers with synthetic dataframe tests and keep data feed stubs explicit

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d92670b8a88327b6de4f397e033046