### PR TITLE
Implement synthetic data feeds and intraday context helpers

### DIFF
--- a/src/pulsar_neuron/lib/data/feeds.py
+++ b/src/pulsar_neuron/lib/data/feeds.py
@@ -1,19 +1,122 @@
 from __future__ import annotations
 
-from typing import Literal
+from datetime import datetime, timedelta
+import math
+from typing import Iterable, Literal
 
 import pandas as pd
 
 Timeframe = Literal["1d", "15m", "5m"]
 
+_FREQ_DELTA: dict[Timeframe, timedelta] = {
+    "1d": timedelta(days=1),
+    "15m": timedelta(minutes=15),
+    "5m": timedelta(minutes=5),
+}
+_DEFAULT_END: dict[Timeframe, datetime] = {
+    "1d": datetime(2025, 1, 31),
+    "15m": datetime(2025, 1, 31, 15, 30),
+    "5m": datetime(2025, 1, 31, 15, 30),
+}
 
-def get_ohlcv(symbol: str, tf: Timeframe, start, end) -> pd.DataFrame:
-    """Stub: implement against your DB/API later."""
 
-    raise NotImplementedError
+def _symbol_seed(symbol: str, tf: Timeframe) -> int:
+    """Create a deterministic integer seed derived from ``symbol`` and ``tf``."""
+
+    payload = f"{symbol}|{tf}".encode("utf-8")
+    return sum(payload) % 10_000
+
+
+def _generate_bars(index: Iterable[datetime], symbol: str, tf: Timeframe) -> pd.DataFrame:
+    """Return a deterministic OHLCV dataframe indexed by ``index``."""
+
+    index_list = list(index)
+    if not index_list:
+        return pd.DataFrame([])
+
+    seed = _symbol_seed(symbol, tf)
+    base_price = 50.0 + (seed % 500) / 5.0
+    amplitude = 1.0 + (seed % 17) / 10.0
+    count = len(index_list)
+    close = []
+    open_ = []
+    high = []
+    low = []
+    volume = []
+    slope = 0.05 + (seed % 7) * 0.01
+    wick = 0.35 + amplitude * 0.05
+    base_volume = 1_000 + (seed % 250) + amplitude * 25.0
+    for i in range(count):
+        trend = i * slope
+        wave = math.sin(i / 3.0 + seed / 13.0) * amplitude
+        close_i = base_price + trend + wave
+        open_i = close_i - math.cos(i / 4.0 + seed / 11.0) * 0.2
+        high_i = max(open_i, close_i) + wick
+        low_i = min(open_i, close_i) - wick
+        volume_i = base_volume + (i % 12) * 40.0
+        close.append(close_i)
+        open_.append(open_i)
+        high.append(high_i)
+        low.append(low_i)
+        volume.append(volume_i)
+
+    rows = []
+    for ts, o, h, l, c, v in zip(index_list, open_, high, low, close, volume):
+        rows.append({"ts": ts, "open": o, "high": h, "low": l, "close": c, "volume": v})
+    return pd.DataFrame(rows)
+
+
+def get_ohlcv(symbol: str, tf: Timeframe, start: datetime | str, end: datetime | str) -> pd.DataFrame:
+    """Return synthetic OHLCV bars for ``symbol`` between ``start`` and ``end``.
+
+    The data is generated deterministically from the inputs so repeated calls with
+    identical arguments return the exact same dataframe.  Columns follow the
+    standard ``ts/open/high/low/close/volume`` schema used across the project.
+    """
+
+    start_ts = start if isinstance(start, datetime) else datetime.fromisoformat(str(start))
+    end_ts = end if isinstance(end, datetime) else datetime.fromisoformat(str(end))
+    if end_ts < start_ts:
+        raise ValueError("end must be greater than or equal to start")
+    step = _FREQ_DELTA[tf]
+    current = start_ts
+    stamps = []
+    while current <= end_ts:
+        stamps.append(current)
+        current += step
+    return _generate_bars(stamps, symbol, tf)
 
 
 def get_last_n(symbol: str, tf: Timeframe, n: int) -> pd.DataFrame:
-    """Stub: implement a fast path later."""
+    """Return the last ``n`` synthetic bars for ``symbol`` at timeframe ``tf``.
 
-    raise NotImplementedError
+    The anchor ``end`` timestamp is deterministic per timeframe to maintain
+    repeatability across test runs.
+    """
+
+    if n < 0:
+        raise ValueError("n must be non-negative")
+    if n == 0:
+        return pd.DataFrame([])
+    end_ts = _DEFAULT_END[tf]
+    step = _FREQ_DELTA[tf]
+    start_ts = end_ts - step * (n - 1)
+    return get_ohlcv(symbol, tf, start_ts, end_ts)
+
+
+def get_live_quote(symbol: str) -> dict[str, float]:
+    """Return a deterministic synthetic live quote snapshot for ``symbol``."""
+
+    latest = get_last_n(symbol, "5m", 1)
+    if latest.empty:
+        return {"ltp": 0.0, "bid": 0.0, "ask": 0.0, "vwap": 0.0}
+    last_row = latest.iloc[-1]
+    last_close = float(last_row["close"])
+    vwap_like = (last_row["high"] + last_row["low"] + last_row["close"]) / 3.0
+    spread = 0.05
+    return {
+        "ltp": last_close,
+        "bid": last_close - spread,
+        "ask": last_close + spread,
+        "vwap": float(vwap_like),
+    }

--- a/src/pulsar_neuron/lib/features/context.py
+++ b/src/pulsar_neuron/lib/features/context.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""Index context builder used by trading brains for NIFTY/BANKNIFTY."""
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+from .indicators import distance_from_vwap_pct, sma_slope, volume_ratio, vwap_from_bars
+from .levels import CPR, HL, ORB, DailyLevels, get_cpr, get_daily_levels, get_intraday_highlow, get_orb
+
+
+@dataclass
+class Trend:
+    """Trend label and SMA slope expressed in absolute price units."""
+
+    label: str
+    slope: float
+
+
+@dataclass
+class IndexContext:
+    """Deterministic snapshot of session state for an index symbol."""
+
+    symbol: str
+    ts: str
+    price: float
+    vwap: float
+    vwap_dist_pct: float
+    orb: ORB
+    cpr: CPR
+    daily: DailyLevels
+    hod_lod: HL
+    trend_15m: Trend
+    trend_5m: Trend
+    vol_ratio_5m: float
+    atr1d_pct: float
+    schema_version: str = "ctx_index_v2"
+
+
+def _trend_from_series(series: pd.Series, n: int) -> Trend:
+    """Return the ``Trend`` representation for the provided closing series."""
+
+    slope = float(sma_slope(series, n))
+    if slope > 0:
+        label = "up"
+    elif slope < 0:
+        label = "down"
+    else:
+        label = "neutral"
+    return Trend(label=label, slope=slope)
+
+
+def build_ctx_index(symbol: str, df_1d: pd.DataFrame, df_15m: pd.DataFrame, df_5m: pd.DataFrame) -> IndexContext:
+    """Build an :class:`IndexContext` using deterministic computations.
+
+    All dataframes must be sorted in ascending order and contain columns
+    ``ts``, ``open``, ``high``, ``low``, ``close`` and ``volume``.
+    """
+
+    if df_5m.empty:
+        return IndexContext(
+            symbol=symbol,
+            ts="",
+            price=0.0,
+            vwap=0.0,
+            vwap_dist_pct=0.0,
+            orb=ORB(0.0, 0.0, False),
+            cpr=CPR(0.0, 0.0, 0.0),
+            daily=DailyLevels(0.0, 0.0, 0.0),
+            hod_lod=HL(0.0, 0.0),
+            trend_15m=Trend("neutral", 0.0),
+            trend_5m=Trend("neutral", 0.0),
+            vol_ratio_5m=1.0,
+            atr1d_pct=0.0,
+        )
+
+    price = float(df_5m["close"].iloc[-1])
+    ts_str = str(df_5m["ts"].iloc[-1])
+    vwap = vwap_from_bars(df_5m)
+    orb = get_orb(df_5m)
+    cpr = get_cpr(df_1d)
+    daily = get_daily_levels(df_1d)
+    hl = get_intraday_highlow(df_5m)
+    trend15 = _trend_from_series(df_15m["close"], 10) if not df_15m.empty else Trend("neutral", 0.0)
+    trend5 = _trend_from_series(df_5m["close"], 10)
+    volr = volume_ratio(df_5m["volume"], 20)
+
+    if len(df_1d) >= 15:
+        atr_points = (df_1d["high"] - df_1d["low"]).rolling(14, min_periods=14).mean().iloc[-1]
+        atr_pct = float((atr_points / df_1d["close"].iloc[-1]) * 100.0)
+    else:
+        atr_pct = 0.0
+
+    return IndexContext(
+        symbol=symbol,
+        ts=ts_str,
+        price=price,
+        vwap=vwap,
+        vwap_dist_pct=distance_from_vwap_pct(price, vwap),
+        orb=orb,
+        cpr=cpr,
+        daily=daily,
+        hod_lod=hl,
+        trend_15m=trend15,
+        trend_5m=trend5,
+        vol_ratio_5m=volr,
+        atr1d_pct=atr_pct,
+        schema_version="ctx_index_v2",
+    )
+

--- a/src/pulsar_neuron/lib/features/levels.py
+++ b/src/pulsar_neuron/lib/features/levels.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+"""Session level helpers used by the intraday context builder."""
+
+from dataclasses import dataclass
+
+import pandas as pd
+
+
+@dataclass
+class DailyLevels:
+    """Previous-day high, low and close levels."""
+
+    pdh: float
+    pdl: float
+    pdc: float
+
+
+@dataclass
+class ORB:
+    """Opening range breakout high/low and readiness flag."""
+
+    high: float
+    low: float
+    ready: bool
+
+
+@dataclass
+class CPR:
+    """Central Pivot Range consisting of pivot, bottom and top central levels."""
+
+    pivot: float
+    bc: float
+    tc: float
+
+
+@dataclass
+class HL:
+    """Intraday high and low computed from the 5-minute dataframe."""
+
+    hod: float
+    lod: float
+
+
+def get_daily_levels(df_1d: pd.DataFrame) -> DailyLevels:
+    """Return previous day high/low/close levels from a daily dataframe."""
+
+    if len(df_1d) < 2:
+        return DailyLevels(0.0, 0.0, 0.0)
+    prev = df_1d.iloc[-2]
+    return DailyLevels(pdh=float(prev["high"]), pdl=float(prev["low"]), pdc=float(prev["close"]))
+
+
+def get_orb(df_5m: pd.DataFrame, window: tuple[str, str] = ("09:15", "09:30")) -> ORB:
+    """Compute the opening range breakout levels within the provided window."""
+
+    if df_5m.empty:
+        return ORB(0.0, 0.0, False)
+    ts_hm = df_5m["ts"].dt.strftime("%H:%M")
+    mask = ts_hm.between(*window)
+    if not mask.any():
+        return ORB(float(df_5m["high"].iloc[0]), float(df_5m["low"].iloc[0]), False)
+    window_df = df_5m.loc[mask]
+    return ORB(float(window_df["high"].max()), float(window_df["low"].min()), True)
+
+
+def get_cpr(df_1d: pd.DataFrame) -> CPR:
+    """Compute the Central Pivot Range from the previous daily bar."""
+
+    if len(df_1d) < 2:
+        return CPR(0.0, 0.0, 0.0)
+    prev = df_1d.iloc[-2]
+    pivot = (prev["high"] + prev["low"] + prev["close"]) / 3.0
+    bc = (prev["high"] + prev["low"]) / 2.0
+    tc = 2 * pivot - bc
+    return CPR(pivot=float(pivot), bc=float(bc), tc=float(tc))
+
+
+def get_intraday_highlow(df_5m: pd.DataFrame) -> HL:
+    """Return the highest and lowest traded prices in the session dataframe."""
+
+    if df_5m.empty:
+        return HL(0.0, 0.0)
+    return HL(float(df_5m["high"].max()), float(df_5m["low"].min()))
+

--- a/tests/test_data_feeds.py
+++ b/tests/test_data_feeds.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pulsar_neuron.lib.data.feeds import get_last_n, get_live_quote, get_ohlcv
+
+
+def test_get_ohlcv_deterministic():
+    start = datetime(2025, 1, 1, 9, 15)
+    end = datetime(2025, 1, 1, 9, 45)
+    bars1 = get_ohlcv("NIFTY", "5m", start, end)
+    bars2 = get_ohlcv("NIFTY", "5m", start, end)
+    assert len(bars1) == len(bars2)
+    assert bars1.iloc[0]["ts"] == bars2.iloc[0]["ts"]
+    assert bars1.iloc[-1]["close"] == bars2.iloc[-1]["close"]
+
+
+def test_get_last_n_shape_and_quote_consistency():
+    bars = get_last_n("BANKNIFTY", "15m", 3)
+    assert len(bars) == 3
+    assert bars.iloc[0]["open"] != 0
+    quote = get_live_quote("BANKNIFTY")
+    assert quote["bid"] < quote["ask"]
+    assert quote["ltp"] == quote["bid"] + 0.05
+
+
+def test_get_last_n_zero_returns_empty():
+    empty = get_last_n("TEST", "1d", 0)
+    assert empty.empty
+

--- a/tests/test_features_full.py
+++ b/tests/test_features_full.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+from pulsar_neuron.lib.features.context import build_ctx_index
+from pulsar_neuron.lib.features.indicators import distance_from_vwap_pct, vwap_from_bars
+from pulsar_neuron.lib.features.levels import get_cpr, get_daily_levels, get_orb
+
+
+def _mk(ts, o, h, l, c, v):
+    return {"ts": ts, "open": o, "high": h, "low": l, "close": c, "volume": v}
+
+
+def test_cpr_and_daily_levels():
+    d1 = pd.DataFrame([
+        _mk("2025-09-26", 1, 2, 0.5, 1.5, 0),
+        _mk("2025-09-29", 1, 2, 0.5, 1.6, 0),
+    ])
+    d1["ts"] = pd.to_datetime(d1["ts"])
+    cpr = get_cpr(d1)
+    daily = get_daily_levels(d1)
+    assert cpr.pivot > 0 and daily.pdh > 0
+
+
+def test_vwap_distance_and_orb():
+    m5 = pd.DataFrame(
+        [
+            _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+            _mk("2025-09-29 09:20", 105, 108, 104, 107, 12),
+            _mk("2025-09-29 09:25", 107, 113, 106, 112, 20),
+            _mk("2025-09-29 09:30", 112, 115, 110, 114, 18),
+        ]
+    )
+    m5["ts"] = pd.to_datetime(m5["ts"])
+    vw = vwap_from_bars(m5)
+    dist = distance_from_vwap_pct(114, vw)
+    orb = get_orb(m5)
+    assert vw > 0 and abs(dist) < 5 and orb.ready
+
+
+def test_build_ctx_index_full():
+    d1 = pd.DataFrame([
+        _mk("2025-09-26", 100, 110, 90, 105, 1000),
+        _mk("2025-09-29", 105, 115, 95, 110, 1200),
+    ])
+    d1["ts"] = pd.to_datetime(d1["ts"])
+    m15 = pd.DataFrame([
+        _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+        _mk("2025-09-29 09:30", 106, 112, 104, 111, 15),
+    ])
+    m15["ts"] = pd.to_datetime(m15["ts"])
+    m5 = pd.DataFrame([
+        _mk("2025-09-29 09:15", 100, 110, 95, 105, 10),
+        _mk("2025-09-29 09:20", 105, 108, 104, 107, 12),
+    ])
+    m5["ts"] = pd.to_datetime(m5["ts"])
+    ctx = build_ctx_index("NIFTY", d1, m15, m5)
+    assert ctx.price > 0
+    assert ctx.cpr.pivot > 0
+    assert ctx.daily.pdh > 0


### PR DESCRIPTION
## Summary
- implement deterministic synthetic OHLCV generators and quote helper for offline testing
- add indicator, level, and context builders tailored for NIFTY/BANKNIFTY intraday analysis
- cover data and feature layers with synthetic bar test suites

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d9290aa25883278c5adb8fcf45b037