### PR TITLE
Add pure EMA, RSI, and ATR helpers with tests

### DIFF
--- a/src/pulsar_neuron/lib/features/indicators.py
+++ b/src/pulsar_neuron/lib/features/indicators.py
@@ -56,3 +56,106 @@ def distance_from_vwap_pct(price: float, vwap: float) -> float:
         return 0.0
     return ((price - vwap) / vwap) * 100.0
 
+
+def ema(series: pd.Series, span: int) -> pd.Series:
+    """Return the exponential moving average using a smoothing ``span``.
+
+    The function requires ``span`` strictly greater than zero and propagates
+    ``NaN`` values until enough observations are available.
+    """
+
+    if span <= 0:
+        raise ValueError("span must be a positive integer")
+    values = [float(v) for v in series]
+    length = len(values)
+    ema_values: list[float | None] = [None] * length
+    if length < span:
+        return pd.Series(ema_values, name=getattr(series, "name", None))
+
+    alpha = 2.0 / (span + 1.0)
+    initial = sum(values[:span]) / span
+    ema_values[span - 1] = float(initial)
+    prev = initial
+    for idx in range(span, length):
+        prev = (values[idx] - prev) * alpha + prev
+        ema_values[idx] = float(prev)
+
+    return pd.Series(ema_values, name=getattr(series, "name", None))
+
+
+def rsi(series: pd.Series, n: int = 14) -> pd.Series:
+    """Return the Relative Strength Index computed with Wilder smoothing."""
+
+    if n <= 0:
+        raise ValueError("n must be a positive integer")
+
+    values = [float(v) for v in series]
+    length = len(values)
+    rsi_values: list[float | None] = [None] * length
+
+    if length <= n:
+        return pd.Series(rsi_values, name=getattr(series, "name", None))
+
+    gains = [0.0] * length
+    losses = [0.0] * length
+    for idx in range(1, length):
+        change = values[idx] - values[idx - 1]
+        if change > 0:
+            gains[idx] = change
+        elif change < 0:
+            losses[idx] = -change
+
+    initial_gain = sum(gains[1 : n + 1]) / n
+    initial_loss = sum(losses[1 : n + 1]) / n
+    avg_gain = initial_gain
+    avg_loss = initial_loss
+
+    rsi_values[n] = _rsi_from_averages(avg_gain, avg_loss)
+    for idx in range(n + 1, length):
+        avg_gain = ((avg_gain * (n - 1)) + gains[idx]) / n
+        avg_loss = ((avg_loss * (n - 1)) + losses[idx]) / n
+        rsi_values[idx] = _rsi_from_averages(avg_gain, avg_loss)
+
+    return pd.Series(rsi_values, name=getattr(series, "name", None))
+
+
+def _rsi_from_averages(avg_gain: float, avg_loss: float, tol: float = 1e-12) -> float:
+    if abs(avg_loss) <= tol and abs(avg_gain) <= tol:
+        return 50.0
+    if abs(avg_loss) <= tol:
+        return 100.0
+    if abs(avg_gain) <= tol:
+        return 0.0
+    rs = avg_gain / avg_loss
+    return 100.0 - (100.0 / (1.0 + rs))
+
+
+def true_range(df: pd.DataFrame) -> pd.Series:
+    """Return the True Range series for a price dataframe."""
+
+    highs = [float(v) for v in df["high"]]
+    lows = [float(v) for v in df["low"]]
+    closes = [float(v) for v in df["close"]]
+
+    tr_values: list[float] = []
+    for idx, (high, low) in enumerate(zip(highs, lows)):
+        range_hl = high - low
+        if idx == 0:
+            tr_values.append(float(range_hl))
+            continue
+        prev_close = closes[idx - 1]
+        range_high = abs(high - prev_close)
+        range_low = abs(low - prev_close)
+        tr_values.append(float(max(range_hl, range_high, range_low)))
+
+    return pd.Series(tr_values, name="true_range")
+
+
+def average_true_range(df: pd.DataFrame, n: int) -> pd.Series:
+    """Return the rolling Average True Range over a window of ``n`` bars."""
+
+    if n <= 0:
+        raise ValueError("n must be a positive integer")
+    tr = true_range(df)
+    return tr.rolling(window=n, min_periods=n).mean()
+

--- a/tests/test_features_indicators.py
+++ b/tests/test_features_indicators.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from pulsar_neuron.lib.features.indicators import (
+    average_true_range,
+    distance_from_vwap_pct,
+    ema,
+    rsi,
+    true_range,
+    vwap_from_bars,
+)
+
+
+def _synthetic_ohlcv(rows: int) -> pd.DataFrame:
+    base = datetime(2024, 1, 1)
+    data_rows = []
+    for i in range(rows):
+        data_rows.append(
+            {
+                "ts": base + timedelta(minutes=i),
+                "open": 100.0 + float(i),
+                "high": 101.0 + float(i),
+                "low": 99.0 + float(i),
+                "close": 100.5 + float(i),
+                "volume": 1000.0 + float(10 * i),
+            }
+        )
+    return pd.DataFrame(data_rows)
+
+
+def _assert_series_values(series: pd.Series, expected: list[float | None]) -> None:
+    actual = series.to_list()
+    assert len(actual) == len(expected)
+    for got, exp in zip(actual, expected):
+        if exp is None:
+            assert got is None
+        else:
+            assert got == pytest.approx(exp, abs=1e-6)
+
+
+def test_ema_matches_manual_computation() -> None:
+    series = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+    result = ema(series, span=3)
+    expected = [None, None, 2.0, 3.0, 4.0]
+    _assert_series_values(result, expected)
+
+
+@pytest.mark.parametrize(
+    "prices, expected",
+    [
+        ([1.0] * 10, 50.0),
+        ([float(i) for i in range(1, 11)], 100.0),
+        ([float(i) for i in range(10, 0, -1)], 0.0),
+    ],
+)
+def test_rsi_edge_cases(prices: list[float], expected: float) -> None:
+    series = pd.Series(prices)
+    result = rsi(series, n=3)
+    assert pytest.approx(result.to_list()[-1], abs=1e-6) == expected
+
+
+def test_true_range_and_average_true_range() -> None:
+    base = datetime(2024, 1, 1)
+    rows = [
+        {"ts": base, "open": 9.0, "high": 11.0, "low": 9.0, "close": 10.0, "volume": 1000.0},
+        {
+            "ts": base + timedelta(minutes=1),
+            "open": 10.0,
+            "high": 12.0,
+            "low": 10.0,
+            "close": 11.0,
+            "volume": 1010.0,
+        },
+        {
+            "ts": base + timedelta(minutes=2),
+            "open": 11.0,
+            "high": 13.0,
+            "low": 11.0,
+            "close": 12.0,
+            "volume": 1020.0,
+        },
+        {
+            "ts": base + timedelta(minutes=3),
+            "open": 12.0,
+            "high": 13.5,
+            "low": 11.5,
+            "close": 12.5,
+            "volume": 1030.0,
+        },
+        {
+            "ts": base + timedelta(minutes=4),
+            "open": 12.5,
+            "high": 16.5,
+            "low": 12.5,
+            "close": 13.5,
+            "volume": 1040.0,
+        },
+    ]
+    df = pd.DataFrame(rows)
+
+    tr = true_range(df)
+    assert tr.to_list() == [2.0, 2.0, 2.0, 2.0, 4.0]
+
+    atr = average_true_range(df, 3)
+    expected_atr = [None, None, 2.0, 2.0, 8.0 / 3.0]
+    _assert_series_values(atr, expected_atr)
+
+
+def test_vwap_helpers_consistency() -> None:
+    df = _synthetic_ohlcv(3)
+    vwap = vwap_from_bars(df)
+    price = df["close"].iloc[-1]
+    dist = distance_from_vwap_pct(price, vwap)
+
+    assert vwap > 0
+    assert dist == pytest.approx((price - vwap) / vwap * 100.0)


### PR DESCRIPTION
## Summary
- add deterministic EMA, RSI, true range, and ATR helpers to the indicator module without introducing stateful dependencies
- cover the new helpers and existing VWAP distance logic with focused synthetic-data tests

## Testing
- PYTHONPATH=src poetry run pytest tests/test_features_indicators.py

------
https://chatgpt.com/codex/tasks/task_e_68d98c36ec788327bf65afda2b3ac088