### PR TITLE
Add IST time utilities and validators with tests

### DIFF
--- a/src/pulsar_neuron/lib/__init__.py
+++ b/src/pulsar_neuron/lib/__init__.py
@@ -1,0 +1,7 @@
+"""Utility modules for Pulsar Neuron."""
+
+from .timeutils import *  # noqa: F401,F403
+from .validators import *  # noqa: F401,F403
+
+__all__ = []  # populated by imported modules
+

--- a/src/pulsar_neuron/lib/timeutils.py
+++ b/src/pulsar_neuron/lib/timeutils.py
@@ -1,0 +1,180 @@
+"""Time and session utilities for IST-aware trading bars."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time, timedelta, timezone
+from typing import Literal
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+Timeframe = Literal["5m", "15m", "1d"]
+
+_IST_ZONE = ZoneInfo("Asia/Kolkata")
+_SESSION_START = time(9, 15)
+_SESSION_END = time(15, 30)
+_TF_TO_MINUTES = {"5m": 5, "15m": 15, "1d": 1440}
+
+
+def ist_tz() -> ZoneInfo:
+    """Return the reusable IST timezone instance."""
+
+    return _IST_ZONE
+
+
+def _ensure_tzaware(dt: datetime) -> None:
+    if dt.tzinfo is None:
+        raise ValueError("Datetime must be timezone-aware")
+
+
+def to_ist(dt: datetime) -> datetime:
+    """Convert ``dt`` to IST, treating naive input as UTC."""
+
+    if dt.tzinfo is None:
+        logger.debug("Converting naive datetime to IST by assuming UTC: %s", dt)
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_IST_ZONE)
+
+
+def session_bounds(d: date) -> tuple[datetime, datetime]:
+    """Return the start and end of the trading session in IST for ``d``."""
+
+    start = datetime.combine(d, _SESSION_START, tzinfo=_IST_ZONE)
+    end = datetime.combine(d, _SESSION_END, tzinfo=_IST_ZONE)
+    return start, end
+
+
+def tf_minutes(tf: Timeframe) -> int:
+    """Return timeframe length in minutes."""
+
+    try:
+        return _TF_TO_MINUTES[tf]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported timeframe: {tf!r}") from exc
+
+
+def is_intraday(tf: Timeframe) -> bool:
+    """Return ``True`` for intraday timeframes."""
+
+    return tf in ("5m", "15m")
+
+
+def _require_ist(ts: datetime) -> datetime:
+    _ensure_tzaware(ts)
+    return to_ist(ts)
+
+
+def is_bar_boundary(ts: datetime, tf: Timeframe) -> bool:
+    """Return ``True`` if ``ts`` is a valid bar boundary for ``tf``."""
+
+    ts_ist = _require_ist(ts)
+    if ts_ist.second != 0 or ts_ist.microsecond != 0:
+        return False
+
+    if tf == "1d":
+        _, session_end = session_bounds(ts_ist.date())
+        return ts_ist == session_end
+
+    start, end = session_bounds(ts_ist.date())
+    if ts_ist <= start or ts_ist > end:
+        return False
+    delta = ts_ist - start
+    minutes = int(delta.total_seconds() // 60)
+    interval = tf_minutes(tf)
+    return minutes % interval == 0
+
+
+def floor_to_tf(ts: datetime, tf: Timeframe) -> datetime:
+    """Floor ``ts`` to the most recent bar boundary for ``tf`` in IST."""
+
+    ts_ist = _require_ist(ts)
+
+    if tf == "1d":
+        start, end = session_bounds(ts_ist.date())
+        if ts_ist >= start:
+            return end
+        previous_day = ts_ist.date() - timedelta(days=1)
+        return session_bounds(previous_day)[1]
+
+    start, end = session_bounds(ts_ist.date())
+    if ts_ist < start:
+        previous_day = ts_ist.date() - timedelta(days=1)
+        return session_bounds(previous_day)[1]
+    if ts_ist >= end:
+        return end
+
+    delta = ts_ist - start
+    minutes = int(delta.total_seconds() // 60)
+    interval = tf_minutes(tf)
+    floored_minutes = (minutes // interval) * interval
+    return start + timedelta(minutes=floored_minutes)
+
+
+def next_bar_end(after: datetime, tf: Timeframe) -> datetime:
+    """Return the next bar boundary strictly greater than ``after``."""
+
+    ts_ist = _require_ist(after)
+
+    if tf == "1d":
+        _, end = session_bounds(ts_ist.date())
+        if ts_ist < end:
+            return end
+        next_day = ts_ist.date() + timedelta(days=1)
+        return session_bounds(next_day)[1]
+
+    interval = tf_minutes(tf)
+    start, end = session_bounds(ts_ist.date())
+    if ts_ist >= end:
+        next_day = ts_ist.date() + timedelta(days=1)
+        next_start, _ = session_bounds(next_day)
+        return next_start + timedelta(minutes=interval)
+
+    if ts_ist <= start:
+        return start + timedelta(minutes=interval)
+
+    delta = ts_ist - start
+    minutes = int(delta.total_seconds() // 60)
+    next_multiple = ((minutes // interval) + 1) * interval
+    candidate = start + timedelta(minutes=next_multiple)
+    if candidate <= ts_ist:
+        candidate += timedelta(minutes=interval)
+    return candidate
+
+
+def is_within_session(ts: datetime) -> bool:
+    """Return ``True`` if ``ts`` lies within the IST trading session."""
+
+    ts_ist = _require_ist(ts)
+    start, end = session_bounds(ts_ist.date())
+    return start <= ts_ist <= end
+
+
+def is_bar_complete(ts: datetime, tf: Timeframe) -> bool:
+    """Pure check for bar completeness (alignment and session membership)."""
+
+    ts_ist = _require_ist(ts)
+
+    if tf == "1d":
+        return is_bar_boundary(ts_ist, tf)
+
+    return is_bar_boundary(ts_ist, tf) and is_within_session(ts_ist)
+
+
+def within_orb(ts: datetime, start: str = "09:15", end: str = "09:30") -> bool:
+    """Return whether ``ts`` falls within the Opening Range Breakout window."""
+
+    ts_ist = _require_ist(ts)
+
+    try:
+        start_h, start_m = (int(part) for part in start.split(":", 1))
+        end_h, end_m = (int(part) for part in end.split(":", 1))
+    except ValueError as exc:  # pragma: no cover - invalid configuration
+        raise ValueError("ORB start/end must be in HH:MM format") from exc
+
+    start_dt = datetime.combine(ts_ist.date(), time(start_h, start_m), tzinfo=_IST_ZONE)
+    end_dt = datetime.combine(ts_ist.date(), time(end_h, end_m), tzinfo=_IST_ZONE)
+    if end_dt <= start_dt:
+        raise ValueError("ORB end time must be after start time")
+    return start_dt <= ts_ist < end_dt
+

--- a/src/pulsar_neuron/lib/validators.py
+++ b/src/pulsar_neuron/lib/validators.py
@@ -1,0 +1,121 @@
+"""Validation helpers for OHLCV bars."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Iterable, Mapping, Sequence, cast
+
+from .timeutils import (
+    Timeframe,
+    is_bar_boundary,
+    is_bar_complete,
+    is_intraday,
+    is_within_session,
+    tf_minutes,
+)
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_OHLCV_KEYS = ("symbol", "ts_ist", "tf", "o", "h", "l", "c", "v")
+
+
+def require_keys(d: Mapping, keys: Sequence[str]) -> None:
+    """Ensure that ``d`` contains ``keys``; raise with missing ones otherwise."""
+
+    missing = [key for key in keys if key not in d]
+    if missing:
+        logger.debug("Missing keys detected: %s", missing)
+        raise KeyError(f"Missing keys: {', '.join(missing)}")
+
+
+def _is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def validate_ohlcv_row(row: Mapping) -> None:
+    """Validate structure, types, and invariants of an OHLCV row."""
+
+    require_keys(row, REQUIRED_OHLCV_KEYS)
+
+    symbol = row["symbol"]
+    if not isinstance(symbol, str) or not symbol:
+        raise ValueError("'symbol' must be a non-empty string")
+
+    ts = row["ts_ist"]
+    if not isinstance(ts, datetime):
+        raise ValueError("'ts_ist' must be a datetime instance")
+    if ts.tzinfo is None:
+        raise ValueError("'ts_ist' must be timezone-aware and in IST")
+    if getattr(ts.tzinfo, "key", None) != "Asia/Kolkata":
+        raise ValueError("'ts_ist' must be in Asia/Kolkata timezone")
+
+    tf = row["tf"]
+    if not isinstance(tf, str):
+        raise ValueError("'tf' must be a string")
+    try:
+        tf_minutes(tf)  # type: ignore[arg-type]
+    except ValueError as exc:
+        raise ValueError("Unsupported timeframe value") from exc
+    timeframe = cast(Timeframe, tf)
+
+    prices = {key: row[key] for key in ("o", "h", "l", "c")}
+    for key, value in prices.items():
+        if not _is_number(value):
+            raise ValueError(f"'{key}' must be a numeric value")
+        if value <= 0:
+            raise ValueError(f"'{key}' must be positive")
+
+    low = float(prices["l"])
+    high = float(prices["h"])
+    open_ = float(prices["o"])
+    close = float(prices["c"])
+    if low > min(open_, close, high):
+        raise ValueError("'l' must be less than or equal to min(o, c, h)")
+    if high < max(open_, close, low):
+        raise ValueError("'h' must be greater than or equal to max(o, c, l)")
+
+    volume = row["v"]
+    if not isinstance(volume, int) or volume < 0:
+        raise ValueError("'v' must be a non-negative integer")
+
+    if is_intraday(timeframe) and not is_within_session(ts):
+        raise ValueError("'ts_ist' must fall within the trading session for intraday bars")
+
+    if not is_bar_boundary(ts, timeframe):
+        raise ValueError("'ts_ist' is not aligned to a valid bar boundary")
+
+
+def enforce_bar_complete(row: Mapping) -> None:
+    """Ensure that a row represents a complete bar."""
+
+    ts = row.get("ts_ist")
+    tf = row.get("tf")
+    if not isinstance(ts, datetime) or not isinstance(tf, str):
+        raise ValueError("Row must contain 'ts_ist' datetime and 'tf' string")
+    if getattr(ts.tzinfo, "key", None) != "Asia/Kolkata":
+        raise ValueError("'ts_ist' must be in Asia/Kolkata timezone")
+    if tf not in ("5m", "15m", "1d"):
+        raise ValueError("Unsupported timeframe value")
+    timeframe: Timeframe = cast(Timeframe, tf)
+    if not is_bar_complete(ts, timeframe):
+        raise ValueError("Bar is not complete for the given timeframe")
+
+
+def ensure_sorted_unique(bars: Iterable[Mapping]) -> None:
+    """Ensure ``bars`` are strictly increasing in ``ts_ist`` with no duplicates."""
+
+    last_ts: datetime | None = None
+    for row in bars:
+        ts = row.get("ts_ist")
+        if not isinstance(ts, datetime):
+            raise ValueError("Each bar must contain a 'ts_ist' datetime")
+        if ts.tzinfo is None:
+            raise ValueError("'ts_ist' values must be timezone-aware")
+        if getattr(ts.tzinfo, "key", None) != "Asia/Kolkata":
+            raise ValueError("All 'ts_ist' values must be in Asia/Kolkata timezone")
+
+        if last_ts is not None and ts <= last_ts:
+            raise ValueError("Bars must be strictly increasing in 'ts_ist'")
+        last_ts = ts
+

--- a/tests/test_timeutils.py
+++ b/tests/test_timeutils.py
@@ -1,0 +1,90 @@
+from datetime import datetime
+
+from pulsar_neuron.lib.timeutils import (
+    floor_to_tf,
+    is_bar_boundary,
+    is_bar_complete,
+    ist_tz,
+    next_bar_end,
+    session_bounds,
+    to_ist,
+    within_orb,
+)
+
+
+def test_ist_timezone():
+    tz = ist_tz()
+    assert tz.key == "Asia/Kolkata"
+
+
+def test_to_ist_from_naive_utc():
+    utc_now = datetime(2024, 1, 1, 0, 0, 0)
+    ist = to_ist(utc_now)
+    assert ist.tzinfo.key == "Asia/Kolkata"
+    assert ist.hour == 5 and ist.minute == 30
+
+
+def test_to_ist_from_aware():
+    aware = datetime(2024, 1, 1, 9, 15, tzinfo=ist_tz())
+    ist = to_ist(aware)
+    assert ist == aware
+
+
+def test_session_bounds():
+    start, end = session_bounds(datetime(2024, 1, 1).date())
+    assert start.hour == 9 and start.minute == 15
+    assert end.hour == 15 and end.minute == 30
+    assert start.tzinfo.key == "Asia/Kolkata"
+
+
+def test_is_bar_boundary_5m():
+    tz = ist_tz()
+    assert is_bar_boundary(datetime(2024, 1, 1, 9, 20, tzinfo=tz), "5m")
+    assert not is_bar_boundary(datetime(2024, 1, 1, 9, 22, tzinfo=tz), "5m")
+    assert is_bar_boundary(datetime(2024, 1, 1, 15, 30, tzinfo=tz), "5m")
+
+
+def test_is_bar_boundary_15m():
+    tz = ist_tz()
+    assert is_bar_boundary(datetime(2024, 1, 1, 9, 30, tzinfo=tz), "15m")
+    assert is_bar_boundary(datetime(2024, 1, 1, 9, 45, tzinfo=tz), "15m")
+    assert not is_bar_boundary(datetime(2024, 1, 1, 9, 35, tzinfo=tz), "15m")
+    assert is_bar_boundary(datetime(2024, 1, 1, 15, 30, tzinfo=tz), "15m")
+
+
+def test_is_bar_boundary_daily():
+    tz = ist_tz()
+    assert is_bar_boundary(datetime(2024, 1, 1, 15, 30, tzinfo=tz), "1d")
+    assert not is_bar_boundary(datetime(2024, 1, 1, 15, 29, tzinfo=tz), "1d")
+
+
+def test_is_bar_complete_intraday():
+    tz = ist_tz()
+    assert is_bar_complete(datetime(2024, 1, 1, 9, 30, tzinfo=tz), "15m")
+    assert not is_bar_complete(datetime(2024, 1, 1, 9, 15, tzinfo=tz), "15m")
+
+
+def test_is_bar_complete_daily():
+    tz = ist_tz()
+    assert is_bar_complete(datetime(2024, 1, 1, 15, 30, tzinfo=tz), "1d")
+    assert not is_bar_complete(datetime(2024, 1, 1, 9, 30, tzinfo=tz), "1d")
+
+
+def test_within_orb():
+    tz = ist_tz()
+    assert within_orb(datetime(2024, 1, 1, 9, 15, tzinfo=tz))
+    assert within_orb(datetime(2024, 1, 1, 9, 29, tzinfo=tz))
+    assert not within_orb(datetime(2024, 1, 1, 9, 30, tzinfo=tz))
+
+
+def test_floor_to_tf():
+    tz = ist_tz()
+    floored = floor_to_tf(datetime(2024, 1, 1, 9, 17, tzinfo=tz), "5m")
+    assert floored == datetime(2024, 1, 1, 9, 15, tzinfo=tz)
+
+
+def test_next_bar_end():
+    tz = ist_tz()
+    nxt = next_bar_end(datetime(2024, 1, 1, 9, 15, tzinfo=tz), "5m")
+    assert nxt == datetime(2024, 1, 1, 9, 20, tzinfo=tz)
+

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+
+import pytest
+
+from pulsar_neuron.lib.timeutils import ist_tz
+from pulsar_neuron.lib.validators import (
+    enforce_bar_complete,
+    ensure_sorted_unique,
+    validate_ohlcv_row,
+)
+
+
+def _base_row(**overrides):
+    tz = ist_tz()
+    row = {
+        "symbol": "TEST",
+        "ts_ist": datetime(2024, 1, 1, 9, 30, tzinfo=tz),
+        "tf": "15m",
+        "o": 100.0,
+        "h": 110.0,
+        "l": 95.0,
+        "c": 105.0,
+        "v": 10,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_validate_row_success():
+    validate_ohlcv_row(_base_row())
+
+
+def test_validate_row_invalid_prices():
+    with pytest.raises(ValueError):
+        validate_ohlcv_row(_base_row(l=120))
+
+
+def test_validate_row_naive_timestamp():
+    with pytest.raises(ValueError):
+        validate_ohlcv_row(_base_row(ts_ist=datetime(2024, 1, 1, 9, 30)))
+
+
+def test_validate_row_non_boundary():
+    tz = ist_tz()
+    with pytest.raises(ValueError):
+        validate_ohlcv_row(_base_row(ts_ist=datetime(2024, 1, 1, 9, 32, tzinfo=tz)))
+
+
+def test_enforce_bar_complete():
+    enforce_bar_complete(_base_row())
+    with pytest.raises(ValueError):
+        enforce_bar_complete(_base_row(ts_ist=datetime(2024, 1, 1, 9, 15, tzinfo=ist_tz())))
+
+
+def test_ensure_sorted_unique_duplicate():
+    tz = ist_tz()
+    rows = [
+        _base_row(ts_ist=datetime(2024, 1, 1, 9, 30, tzinfo=tz)),
+        _base_row(ts_ist=datetime(2024, 1, 1, 9, 30, tzinfo=tz)),
+    ]
+    with pytest.raises(ValueError):
+        ensure_sorted_unique(rows)
+


### PR DESCRIPTION
## Summary
- add IST-focused time utility module for session boundaries, bar alignment, and ORB helpers
- introduce OHLCV validation helpers enforcing bar alignment and completeness
- cover new utilities with unit tests for time calculations and validators

## Testing
- PYTHONPATH=src pytest tests/test_timeutils.py tests/test_validators.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e162ed4e3083278713cd9ed23e2ba6