### PR TITLE
Add mock ingestion jobs and CLI harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ advisory:
 
 run-spine:
 	poetry run python -m pulsar_neuron.cli.run_spine
+
+run-ingestors:
+	poetry run python -m pulsar_neuron.cli.run_ingestors

--- a/src/pulsar_neuron/cli/run_ingestors.py
+++ b/src/pulsar_neuron/cli/run_ingestors.py
@@ -1,0 +1,25 @@
+"""
+Test harness for all ingestors (mock-only).
+"""
+from pulsar_neuron.ingest import fut_oi_job, market_job, ohlcv_job, options_job
+
+
+def main():
+    symbols = ["NIFTY 50", "NIFTY BANK"]
+    print("▶️  OHLCV (mock)")
+    bars = ohlcv_job.run(symbols, tf="5m", mode="mock")
+    print(f"✅ {sum(len(v) for v in bars.values())} bars fetched")
+
+    print("▶️  Futures OI (mock)")
+    print(fut_oi_job.run(["NIFTY", "BANKNIFTY"], mode="mock"))
+
+    print("▶️  Options Chain (mock)")
+    opt = options_job.run(["NIFTY", "BANKNIFTY"], mode="mock")
+    print(f"✅ {len(opt)} option records")
+
+    print("▶️  Market Breadth / VIX (mock)")
+    print(market_job.run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/ingest/fut_oi_job.py
+++ b/src/pulsar_neuron/ingest/fut_oi_job.py
@@ -1,7 +1,16 @@
-    """Ingest Futures OI
-    NOTE: Stub module. Add real logic later.
-    """
+"""
+Fetch mock futures OI snapshots.
+Later will pull from Kite quote API.
+"""
+from datetime import datetime, timezone
+import random
 
-def run_once(now_ist: str): ...
-def run_loop(): ...
 
+def run(symbols: list[str], mode: str = "mock"):
+    now = datetime.now(timezone.utc)
+    out = []
+    for s in symbols:
+        price = 20000.0 if "BANK" in s else 2200.0
+        oi = random.randint(1000000, 2500000)
+        out.append({"symbol": s, "ts_ist": now.isoformat(), "price": price, "oi": oi})
+    return out

--- a/src/pulsar_neuron/ingest/market_job.py
+++ b/src/pulsar_neuron/ingest/market_job.py
@@ -1,7 +1,15 @@
-    """Ingest Breadth/VIX
-    NOTE: Stub module. Add real logic later.
-    """
+"""
+Fetch mock market breadth & India VIX.
+Later will read from NSE index API.
+"""
+from datetime import datetime, timezone
+import random
 
-def run_once(now_ist: str): ...
-def run_loop(): ...
 
+def run(mode: str = "mock"):
+    now = datetime.now(timezone.utc)
+    adv = random.randint(100, 300)
+    dec = random.randint(50, 150)
+    unch = random.randint(5, 20)
+    vix = round(random.uniform(10, 18), 2)
+    return {"ts_ist": now.isoformat(), "adv": adv, "dec": dec, "unch": unch, "vix": vix}

--- a/src/pulsar_neuron/ingest/ohlcv_job.py
+++ b/src/pulsar_neuron/ingest/ohlcv_job.py
@@ -1,7 +1,42 @@
-    """Ingest OHLCV
-    NOTE: Stub module. Add real logic later.
-    """
+"""
+Fetch and normalize OHLCV bars (mock mode).
+Later this will read from Kite WebSocket or API.
+"""
+from pulsar_neuron.normalize.ohlcv_norm import normalize_ohlcv
 
-def run_once(now_ist: str): ...
-def run_loop(): ...
 
+def make_mock_bars(symbol: str, tf: str = "5m", limit: int = 120):
+    import math
+    import random
+
+    bars = []
+    base = 20000.0 if "BANK" in symbol else 2200.0
+    for i in range(limit):
+        o = base + math.sin(i / 5) * 10 + random.uniform(-2, 2)
+        h = o + random.uniform(1, 5)
+        l = o - random.uniform(1, 5)
+        c = l + (h - l) * random.random()
+        v = random.randint(500, 2000)
+        bars.append(
+            {
+                "symbol": symbol,
+                "tf": tf,
+                "o": o,
+                "h": h,
+                "l": l,
+                "c": c,
+                "v": v,
+                "ts_ist": f"{i}",
+            }
+        )
+    return bars
+
+
+def run(symbols: list[str], tf: str = "5m", mode: str = "mock"):
+    if mode != "mock":
+        raise NotImplementedError("Only mock mode supported now.")
+    all_data = {}
+    for s in symbols:
+        raw = make_mock_bars(s, tf)
+        all_data[s] = normalize_ohlcv(raw, tf=tf)
+    return all_data

--- a/src/pulsar_neuron/ingest/options_job.py
+++ b/src/pulsar_neuron/ingest/options_job.py
@@ -1,7 +1,35 @@
-    """Ingest Options Chain
-    NOTE: Stub module. Add real logic later.
-    """
+"""
+Fetch mock option chain (ATM ± N strikes).
+Later will use Kite option quote API.
+"""
+from datetime import datetime, timezone
+import random
 
-def run_once(now_ist: str): ...
-def run_loop(): ...
 
+def run(symbols: list[str], mode: str = "mock", strikes: int = 10):
+    now = datetime.now(timezone.utc)
+    chain = []
+    for s in symbols:
+        base = 20000 if "BANK" in s else 2200
+        expiry = "2025-10-10"
+        for i in range(-strikes, strikes + 1):
+            strike = base + i * 100
+            for side in ("CE", "PE"):
+                ltp = round(random.uniform(50, 350), 2)
+                iv = round(random.uniform(10, 30), 2)
+                oi = random.randint(10000, 80000)
+                vol = random.randint(500, 5000)
+                chain.append(
+                    {
+                        "symbol": s,
+                        "ts_ist": now.isoformat(),
+                        "expiry": expiry,
+                        "strike": strike,
+                        "side": side,
+                        "ltp": ltp,
+                        "iv": iv,
+                        "oi": oi,
+                        "volume": vol,
+                    }
+                )
+    return chain

--- a/src/pulsar_neuron/normalize/ohlcv_norm.py
+++ b/src/pulsar_neuron/normalize/ohlcv_norm.py
@@ -1,6 +1,46 @@
-    """Normalize OHLCV
-    NOTE: Stub module. Add real logic later.
+"""Utilities to normalize OHLCV bar payloads."""
+from __future__ import annotations
+
+from datetime import date
+from typing import Iterable
+
+
+def _to_float(value: float | int) -> float:
+    """Convert numeric inputs to floats with two decimal precision."""
+    return round(float(value), 2)
+
+
+def normalize_ohlcv(raw: Iterable[dict], *, tf: str) -> list[dict]:
+    """Normalize raw OHLCV bars into a consistent schema.
+
+    Parameters
+    ----------
+    raw:
+        Iterable of raw bar dictionaries containing ``o``, ``h``, ``l``, ``c``,
+        ``v`` and ``ts_ist`` keys.
+    tf:
+        The timeframe string the bars represent.
+
+    Returns
+    -------
+    list[dict]
+        Normalized bar dictionaries ready for downstream processing.
     """
 
-def normalize_ohlcv(raw: dict) -> dict: ...
-
+    normalized = []
+    trade_date = date.today().isoformat()
+    for bar in raw:
+        normalized.append(
+            {
+                "symbol": bar.get("symbol"),
+                "date": trade_date,
+                "timeframe": tf,
+                "open": _to_float(bar.get("o", 0.0)),
+                "high": _to_float(bar.get("h", 0.0)),
+                "low": _to_float(bar.get("l", 0.0)),
+                "close": _to_float(bar.get("c", 0.0)),
+                "volume": int(bar.get("v", 0)),
+                "ts_ist": bar.get("ts_ist"),
+            }
+        )
+    return normalized


### PR DESCRIPTION
## Summary
- implement mock mock-data ingestion jobs for OHLCV, futures OI, options, and market breadth
- add an OHLCV normalization helper to shape bar payloads for downstream consumers
- provide a CLI harness and Makefile target to run all ingestors together in mock mode

## Testing
- make run-ingestors

------
https://chatgpt.com/codex/tasks/task_e_68e175e7efbc8327b40f7df54141378f