### PR TITLE
Add database support for derivatives persistence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,3 +19,15 @@ run-spine:
 
 run-ingestors:
 	poetry run python -m pulsar_neuron.cli.run_ingestors
+
+db-migrate:
+	poetry run python -m pulsar_neuron.cli.db_init
+
+db-oi-mock:
+	poetry run python -m pulsar_neuron.cli.oi_to_db
+
+db-options-mock:
+	poetry run python -m pulsar_neuron.cli.options_to_db
+
+db-derivs-read:
+	poetry run python -m pulsar_neuron.cli.read_derivs

--- a/src/pulsar_neuron/cli/db_init.py
+++ b/src/pulsar_neuron/cli/db_init.py
@@ -1,0 +1,13 @@
+"""Run database migrations for Pulsar Neuron."""
+from __future__ import annotations
+
+from pulsar_neuron.db.postgres import migrate
+
+
+def main() -> None:
+    migrate()
+    print("✅ migrations applied")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/cli/oi_to_db.py
+++ b/src/pulsar_neuron/cli/oi_to_db.py
@@ -1,0 +1,28 @@
+"""Fetch mock Futures OI via ingest.fut_oi_job and write to DB."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from pulsar_neuron.db.fut_oi_repo import upsert_many
+from pulsar_neuron.ingest import fut_oi_job
+
+
+def _maybe_parse_ts(value):
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return value
+    return value
+
+
+def main() -> None:
+    rows = fut_oi_job.run(["NIFTY", "BANKNIFTY"], mode="mock")
+    for row in rows:
+        row["ts_ist"] = _maybe_parse_ts(row.get("ts_ist"))
+    n = upsert_many(rows)
+    print(f"✅ upserted {n} fut_oi rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/cli/options_to_db.py
+++ b/src/pulsar_neuron/cli/options_to_db.py
@@ -1,0 +1,31 @@
+"""Fetch mock Options Chain via ingest.options_job and write to DB."""
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from pulsar_neuron.db.options_repo import upsert_many
+from pulsar_neuron.ingest import options_job
+
+
+def _maybe_parse_ts(value):
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return value
+    return value
+
+
+def main() -> None:
+    rows = options_job.run(["NIFTY", "BANKNIFTY"], mode="mock", strikes=3)
+    for row in rows:
+        expiry = row.get("expiry")
+        if isinstance(expiry, str):
+            row["expiry"] = date.fromisoformat(expiry)
+        row["ts_ist"] = _maybe_parse_ts(row.get("ts_ist"))
+    n = upsert_many(rows)
+    print(f"✅ upserted {n} options_chain rows")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/cli/read_derivs.py
+++ b/src/pulsar_neuron/cli/read_derivs.py
@@ -1,0 +1,22 @@
+"""Read latest OI and Options snapshot from DB and print small summaries."""
+from __future__ import annotations
+
+from pulsar_neuron.db.fut_oi_repo import read_last
+from pulsar_neuron.db.options_repo import read_latest_snapshot
+
+
+def main() -> None:
+    for symbol in ["NIFTY", "BANKNIFTY"]:
+        fut = read_last(symbol, limit=5)
+        print(f"\n{symbol} — OI last {len(fut)}:")
+        print(fut[:2])
+
+        chain = read_latest_snapshot(symbol)
+        strikes = sorted({row["strike"] for row in chain})
+        print(
+            f"{symbol} — latest snapshot strikes: {strikes[:6]}  (total rows: {len(chain)})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/db/fut_oi_repo.py
+++ b/src/pulsar_neuron/db/fut_oi_repo.py
@@ -1,7 +1,51 @@
-    """Futures OI repo
-    NOTE: Stub module. Add real logic later.
-    """
+"""Futures OI repository — UPSERT and reads."""
+from __future__ import annotations
 
-def upsert_oi(rows: list[dict]): ...
-def latest_oi(symbol: str) -> dict: ...
+from datetime import datetime
+from typing import Dict, Iterable, List, Mapping
 
+from .postgres import get_conn
+
+UPSERT_SQL = """
+insert into fut_oi(symbol, ts_ist, price, oi, tag)
+values (%(symbol)s, %(ts_ist)s, %(price)s, %(oi)s, %(tag)s)
+on conflict (symbol, ts_ist) do update
+set price = excluded.price, oi = excluded.oi, tag = excluded.tag;
+"""
+
+READ_LAST_SQL = """
+select symbol, ts_ist, price, oi, tag
+from fut_oi
+where symbol = %s
+order by ts_ist desc
+limit %s
+"""
+
+READ_RANGE_SQL = """
+select symbol, ts_ist, price, oi, tag
+from fut_oi
+where symbol = %s and ts_ist between %s and %s
+order by ts_ist asc
+"""
+
+
+def upsert_many(rows: Iterable[Mapping]) -> int:
+    rows = list(rows)
+    if not rows:
+        return 0
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.executemany(UPSERT_SQL, rows)
+        conn.commit()
+        return cur.rowcount
+
+
+def read_last(symbol: str, limit: int = 50) -> List[Dict]:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(READ_LAST_SQL, (symbol, limit))
+        return cur.fetchall()
+
+
+def read_range(symbol: str, start: datetime, end: datetime) -> List[Dict]:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(READ_RANGE_SQL, (symbol, start, end))
+        return cur.fetchall()

--- a/src/pulsar_neuron/db/options_repo.py
+++ b/src/pulsar_neuron/db/options_repo.py
@@ -1,7 +1,57 @@
-    """Options chain repo
-    NOTE: Stub module. Add real logic later.
-    """
+"""Options Chain repository — UPSERT and reads."""
+from __future__ import annotations
 
-def upsert_chain(rows: list[dict]): ...
-def latest_chain_slice(symbol: str) -> list[dict]: ...
+from typing import Dict, Iterable, List, Mapping
 
+from .postgres import get_conn
+
+UPSERT_SQL = """
+insert into options_chain(symbol, ts_ist, expiry, strike, side, ltp, iv, oi, volume, delta, gamma, theta, vega)
+values (%(symbol)s, %(ts_ist)s, %(expiry)s, %(strike)s, %(side)s, %(ltp)s, %(iv)s, %(oi)s, %(volume)s, %(delta)s, %(gamma)s, %(theta)s, %(vega)s)
+on conflict (symbol, ts_ist, expiry, strike, side) do update set
+  ltp = excluded.ltp,
+  iv = excluded.iv,
+  oi = excluded.oi,
+  volume = excluded.volume,
+  delta = excluded.delta,
+  gamma = excluded.gamma,
+  theta = excluded.theta,
+  vega = excluded.vega;
+"""
+
+READ_LAST_TS_SQL = """
+select symbol, ts_ist
+from options_chain
+where symbol = %s
+order by ts_ist desc
+limit 1
+"""
+
+READ_SNAPSHOT_SQL = """
+select symbol, ts_ist, expiry, strike, side, ltp, iv, oi, volume, delta, gamma, theta, vega
+from options_chain
+where symbol = %s and ts_ist = %s
+order by strike asc, side asc
+"""
+
+
+def upsert_many(rows: Iterable[Mapping]) -> int:
+    rows = list(rows)
+    if not rows:
+        return 0
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.executemany(UPSERT_SQL, rows)
+        conn.commit()
+        return cur.rowcount
+
+
+def read_latest_snapshot(symbol: str) -> List[Dict]:
+    """Return the latest full snapshot rows for a symbol; empty if none."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(READ_LAST_TS_SQL, (symbol,))
+        last = cur.fetchone()
+        if not last:
+            return []
+        ts = last["ts_ist"]
+        cur.execute(READ_SNAPSHOT_SQL, (symbol, ts))
+        return cur.fetchall()

--- a/src/pulsar_neuron/db/postgres.py
+++ b/src/pulsar_neuron/db/postgres.py
@@ -1,8 +1,84 @@
-    """Postgres connector
-    NOTE: Stub module. Add real logic later.
-    """
+"""Postgres connector utilities."""
+from __future__ import annotations
 
-def get_conn():
-    """Return DB connection (stub)."""
-    ...
+import os
+from typing import Any, Dict
 
+import psycopg
+from psycopg import Connection
+from psycopg.rows import dict_row
+
+DDL = r"""
+create table if not exists ohlcv (
+  symbol  text not null,
+  ts_ist  timestamptz not null,   -- IST bar END
+  tf      text not null,          -- '5m'|'15m'|'1d'
+  o numeric not null,
+  h numeric not null,
+  l numeric not null,
+  c numeric not null,
+  v bigint  not null,
+  primary key (symbol, ts_ist, tf)
+);
+create index if not exists idx_ohlcv_symbol_tf_ts_desc
+  on ohlcv(symbol, tf, ts_ist desc);
+
+create table if not exists fut_oi (
+  symbol  text not null,
+  ts_ist  timestamptz not null,
+  price   numeric not null,
+  oi      bigint  not null,
+  tag     text default null,        -- 'open_baseline' | 'intraday' | 'close' (optional)
+  primary key (symbol, ts_ist)
+);
+create index if not exists idx_futoi_symbol_ts_desc
+  on fut_oi(symbol, ts_ist desc);
+
+create table if not exists options_chain (
+  symbol  text not null,
+  ts_ist  timestamptz not null,
+  expiry  date not null,
+  strike  numeric not null,
+  side    text not null,            -- 'CE' | 'PE'
+  ltp     numeric not null,
+  iv      numeric,
+  oi      bigint,
+  volume  bigint,
+  delta   numeric,
+  gamma   numeric,
+  theta   numeric,
+  vega    numeric,
+  primary key (symbol, ts_ist, expiry, strike, side)
+);
+create index if not exists idx_opt_symbol_ts
+  on options_chain(symbol, ts_ist desc);
+"""
+
+
+__all__ = ["get_conn", "migrate"]
+
+
+def _conn_kwargs() -> Dict[str, Any]:
+    """Collect connection keyword arguments from environment variables."""
+    mapping = {
+        "host": os.getenv("PGHOST"),
+        "port": os.getenv("PGPORT"),
+        "dbname": os.getenv("PGDATABASE"),
+        "user": os.getenv("PGUSER"),
+        "password": os.getenv("PGPASSWORD"),
+        "sslmode": os.getenv("PGSSLMODE"),
+    }
+    return {k: v for k, v in mapping.items() if v not in (None, "")}
+
+
+def get_conn() -> Connection:
+    """Return a psycopg connection configured with dict-row factory."""
+    return psycopg.connect(**_conn_kwargs(), row_factory=dict_row)
+
+
+def migrate() -> None:
+    """Apply migrations ensuring required tables exist."""
+    with get_conn() as conn:
+        with conn.cursor() as cur:
+            cur.execute(DDL)
+        conn.commit()


### PR DESCRIPTION
## Summary
- implement postgres migrations covering futures OI and options chain tables
- add repositories for futures OI and options chain CRUD operations
- add CLI helpers and make targets to migrate, backfill, and read mock derivatives data

## Testing
- not run (database connectivity not available in CI)


------
https://chatgpt.com/codex/tasks/task_e_68e17bc8655c832787a9f29b11490e88