### PR TITLE
Add live KiteTicker bar builder and runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,6 @@ db-options-mock:
 
 db-derivs-read:
 	poetry run python -m pulsar_neuron.cli.read_derivs
+
+run-live:
+	poetry run python -m pulsar_neuron.cli.live_bars

--- a/src/pulsar_neuron/cli/live_bars.py
+++ b/src/pulsar_neuron/cli/live_bars.py
@@ -1,0 +1,166 @@
+"""CLI to run a live 5-minute bar builder using KiteTicker."""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import threading
+import time
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from pulsar_neuron.ingest.bar_builder import IST, SESSION_START, BarBuilder
+from pulsar_neuron.ingest.derive_tfs import derive_15m
+from pulsar_neuron.db.ohlcv_repo import upsert_many
+
+try:
+    from kiteconnect import KiteTicker
+except Exception:  # pragma: no cover - optional dependency
+    KiteTicker = None  # type: ignore[misc]
+
+
+def _load_tokens() -> Dict[str, int]:
+    raw = os.getenv("KITE_TOKENS_JSON", "")
+    if not raw:
+        raise RuntimeError(
+            "KITE_TOKENS_JSON env missing. Example: '{\"NIFTY 50\":256265, \"NIFTY BANK\":260105}'"
+        )
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - validation
+        raise RuntimeError("KITE_TOKENS_JSON must be valid JSON") from exc
+
+    return {str(symbol): int(token) for symbol, token in payload.items()}
+
+
+def _minutes_since_session_start(ts_ist: datetime) -> int:
+    session_start = ts_ist.replace(
+        hour=SESSION_START.hour,
+        minute=SESSION_START.minute,
+        second=0,
+        microsecond=0,
+    )
+    return int((ts_ist - session_start).total_seconds() // 60)
+
+
+def main() -> None:
+    api_key = os.getenv("KITE_API_KEY")
+    access_token = os.getenv("KITE_ACCESS_TOKEN")
+
+    if not api_key or not access_token:
+        raise RuntimeError("Set KITE_API_KEY and KITE_ACCESS_TOKEN in env")
+
+    if KiteTicker is None:
+        raise RuntimeError("kiteconnect not installed. Install with 'pip install kiteconnect'")
+
+    token_map = _load_tokens()
+    if not token_map:
+        raise RuntimeError("No instruments provided in KITE_TOKENS_JSON")
+
+    symbols = list(token_map.keys())
+    tokens = list(token_map.values())
+    token_to_symbol = {token: symbol for symbol, token in token_map.items()}
+
+    builder = BarBuilder(symbols=symbols, tf="5m")
+    lock = threading.Lock()
+    recent_5m: Dict[str, List[dict]] = {symbol: [] for symbol in symbols}
+    last_15m_upsert: Dict[str, datetime] = {symbol: datetime.min.replace(tzinfo=IST) for symbol in symbols}
+
+    def on_ticks(_ws, ticks: List[Dict]) -> None:  # pragma: no cover - network callback
+        now = datetime.now(timezone.utc)
+        with lock:
+            for tick in ticks:
+                token = int(tick.get("instrument_token", 0))
+                symbol = token_to_symbol.get(token)
+                if not symbol:
+                    continue
+
+                price = float(tick.get("last_price") or tick.get("last_trade_price") or 0.0)
+                if not price:
+                    continue
+
+                volume: Optional[int]
+                if "volume" in tick and tick["volume"] is not None:
+                    volume = int(tick["volume"])
+                else:
+                    volume = None
+
+                builder.on_tick(symbol=symbol, price=price, vol=volume, ts=now)
+
+    def on_connect(ws, _response) -> None:  # pragma: no cover - network callback
+        ws.subscribe(tokens)
+        ws.set_mode(ws.MODE_FULL, tokens)
+
+    def on_close(_ws, code, reason) -> None:  # pragma: no cover - network callback
+        print(f"WebSocket closed: {code} {reason}", file=sys.stderr)
+
+    ticker = KiteTicker(api_key, access_token)
+    ticker.on_ticks = on_ticks
+    ticker.on_connect = on_connect
+    ticker.on_close = on_close
+
+    stop_event = threading.Event()
+
+    def flusher() -> None:
+        while not stop_event.is_set():
+            time.sleep(1)
+            with lock:
+                completed = builder.maybe_close()
+
+            if not completed:
+                continue
+
+            upsert_many(completed)
+
+            for bar in completed:
+                symbol = bar["symbol"]
+                recent_5m[symbol].append(bar)
+                if len(recent_5m[symbol]) > 12:
+                    recent_5m[symbol] = recent_5m[symbol][-12:]
+
+            derived_rows: List[dict] = []
+            for symbol, buf in recent_5m.items():
+                if len(buf) < 3:
+                    continue
+
+                last_three = buf[-3:]
+                last_ts: datetime = last_three[-1]["ts_ist"].astimezone(IST)
+                minutes_since = _minutes_since_session_start(last_ts)
+                if minutes_since % 15 != 0:
+                    continue
+
+                if last_three[-1]["ts_ist"] <= last_15m_upsert[symbol]:
+                    continue
+
+                derived = derive_15m(last_three)
+                if not derived:
+                    continue
+
+                derived_rows.extend(derived)
+                last_15m_upsert[symbol] = last_three[-1]["ts_ist"]
+
+            if derived_rows:
+                upsert_many(derived_rows)
+
+    thread = threading.Thread(target=flusher, daemon=True)
+    thread.start()
+
+    def shutdown(*_args) -> None:
+        stop_event.set()
+        try:
+            ticker.stop()
+        except Exception:  # pragma: no cover - defensive
+            pass
+        thread.join(timeout=2)
+        print("Shutdown complete.")
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    ticker.connect(threaded=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/db/ohlcv_repo.py
+++ b/src/pulsar_neuron/db/ohlcv_repo.py
@@ -5,3 +5,16 @@
 def upsert_bars(rows: list[dict]): ...
 def latest_bar(symbol: str, tf: str) -> dict: ...
 
+
+def upsert_many(rows: list[dict]) -> int:
+    """Compat helper mirroring the other repo interfaces."""
+
+    if not rows:
+        return 0
+
+    result = upsert_bars(rows)
+    if isinstance(result, int):
+        return result
+
+    return len(rows)
+

--- a/src/pulsar_neuron/ingest/bar_builder.py
+++ b/src/pulsar_neuron/ingest/bar_builder.py
@@ -1,0 +1,133 @@
+"""Utilities to aggregate tick data into IST-aligned OHLCV bars."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time, timedelta
+from typing import Dict, List, Literal, Optional
+from zoneinfo import ZoneInfo
+
+Timeframe = Literal["5m", "15m", "1d"]
+
+IST = ZoneInfo("Asia/Kolkata")
+SESSION_START = time(9, 15)
+SESSION_END = time(15, 30)
+
+
+def _now_ist() -> datetime:
+    """Return the current time in IST."""
+    return datetime.now(tz=IST)
+
+
+def _session_bounds(ts: datetime) -> tuple[datetime, datetime]:
+    """Return the start/end datetimes of the trading session for ``ts``."""
+    base = ts.astimezone(IST)
+    start = base.replace(hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0)
+    end = base.replace(hour=SESSION_END.hour, minute=SESSION_END.minute, second=0, microsecond=0)
+    return start, end
+
+
+def _next_5m_end(after: datetime) -> datetime:
+    """Return the next 5-minute bar end after ``after`` (inclusive)."""
+    current = after.astimezone(IST)
+    start, end = _session_bounds(current)
+
+    if current < start:
+        return start + timedelta(minutes=5)
+
+    if current >= end:
+        next_day = (current + timedelta(days=1)).replace(hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0)
+        return next_day + timedelta(minutes=5)
+
+    minutes_since_start = int((current - start).total_seconds() // 60)
+    next_bucket = (minutes_since_start // 5 + 1) * 5
+    return start + timedelta(minutes=next_bucket)
+
+
+@dataclass
+class BarState:
+    ts_end: datetime
+    o: float
+    h: float
+    l: float
+    c: float
+    v: int
+
+
+class BarBuilder:
+    """Maintain per-symbol bar state and emit completed bars on boundaries."""
+
+    def __init__(self, symbols: List[str], tf: Timeframe = "5m"):
+        if tf != "5m":
+            raise ValueError("BarBuilder currently only supports 5m timeframe")
+
+        self.tf = tf
+        self.state: Dict[str, Optional[BarState]] = {symbol: None for symbol in symbols}
+
+    def _ensure_bucket(self, symbol: str, now_ist: datetime, price: float) -> None:
+        state = self.state.get(symbol)
+        if state is not None:
+            return
+
+        ts_end = _next_5m_end(now_ist - timedelta(milliseconds=1))
+        self.state[symbol] = BarState(ts_end=ts_end, o=price, h=price, l=price, c=price, v=0)
+
+    def on_tick(
+        self,
+        symbol: str,
+        price: float,
+        vol: Optional[int] = None,
+        ts: Optional[datetime] = None,
+    ) -> None:
+        now = ts.astimezone(IST) if ts else _now_ist()
+        self._ensure_bucket(symbol, now, price)
+        state = self.state[symbol]
+        if state is None:
+            return
+
+        if price > state.h:
+            state.h = price
+        if price < state.l:
+            state.l = price
+        state.c = price
+
+        if vol is not None:
+            state.v += int(max(vol, 0))
+
+    def _roll_state(self, state: BarState) -> Optional[BarState]:
+        if state.ts_end.astimezone(IST).time() == SESSION_END:
+            return None
+
+        next_end = _next_5m_end(state.ts_end)
+        return BarState(ts_end=next_end, o=state.c, h=state.c, l=state.c, c=state.c, v=0)
+
+    def maybe_close(self, now: Optional[datetime] = None) -> List[dict]:
+        current = now.astimezone(IST) if now else _now_ist()
+        completed: List[dict] = []
+
+        for symbol, state in list(self.state.items()):
+            if state is None:
+                continue
+
+            while current >= state.ts_end:
+                completed.append(
+                    {
+                        "symbol": symbol,
+                        "tf": self.tf,
+                        "ts_ist": state.ts_end,
+                        "o": float(state.o),
+                        "h": float(state.h),
+                        "l": float(state.l),
+                        "c": float(state.c),
+                        "v": int(state.v),
+                    }
+                )
+
+                next_state = self._roll_state(state)
+                self.state[symbol] = next_state
+
+                if next_state is None:
+                    break
+
+                state = next_state
+
+        return completed

--- a/src/pulsar_neuron/ingest/derive_tfs.py
+++ b/src/pulsar_neuron/ingest/derive_tfs.py
@@ -1,0 +1,30 @@
+"""Helpers to derive higher timeframe bars from 5-minute data."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def derive_15m(bars_5m: List[Dict]) -> List[Dict]:
+    """Aggregate sequential 5m bars into a 15m bar."""
+    out: List[Dict] = []
+    buffer: List[Dict] = []
+
+    for bar in bars_5m:
+        buffer.append(bar)
+        if len(buffer) == 3:
+            first, _, last = buffer
+            out.append(
+                {
+                    "symbol": last["symbol"],
+                    "tf": "15m",
+                    "ts_ist": last["ts_ist"],
+                    "o": first["o"],
+                    "h": max(b["h"] for b in buffer),
+                    "l": min(b["l"] for b in buffer),
+                    "c": last["c"],
+                    "v": sum(int(b["v"]) for b in buffer),
+                }
+            )
+            buffer.clear()
+
+    return out


### PR DESCRIPTION
## Summary
- add a 5m BarBuilder that aggregates ticks into IST-aligned OHLCV snapshots
- provide a live KiteTicker CLI that streams ticks into the builder and upserts 5m/15m bars
- expose a derive_15m helper, stub ohlcv upsert_many, and add a run-live Makefile target

## Testing
- PYTHONPATH=src poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17d9214cc8327a6bb5fe894e80850