### PR TITLE
Add live bar ingestion, scheduler, and health watcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,24 @@ db-options-mock:
 	poetry run python -m pulsar_neuron.cli.options_to_db
 
 db-derivs-read:
-	poetry run python -m pulsar_neuron.cli.read_derivs
+        poetry run python -m pulsar_neuron.cli.read_derivs
 
+# Live bars (WebSocket → ohlcv 5m + derived 15m)
 run-live:
-	poetry run python -m pulsar_neuron.cli.live_bars
+        poetry run python -m pulsar_neuron.cli.live_bars
+
+# Aligned scheduler (OI / Options / later breadth-vix)
+run-scheduler:
+        poetry run python -m pulsar_neuron.cli.run_scheduler
+
+# Health watcher (prints latest timestamps from DB)
+watch-health:
+        poetry run python -m pulsar_neuron.cli.watch_health
+
+# Usage:
+#   export PGHOST=... PGDATABASE=... PGUSER=... PGPASSWORD=...
+#   export KITE_API_KEY=... KITE_ACCESS_TOKEN=...
+#   export KITE_TOKENS_JSON='{"NIFTY 50":256265,"NIFTY BANK":260105}'
+#   make run-live          # process 1: emits 5m/15m
+#   make run-scheduler     # process 2: OI/Options cadence
+#   make watch-health      # sanity timestamps

--- a/src/pulsar_neuron/cli/live_bars.py
+++ b/src/pulsar_neuron/cli/live_bars.py
@@ -1,4 +1,3 @@
-"""CLI to run a live 5-minute bar builder using KiteTicker."""
 from __future__ import annotations
 
 import json
@@ -8,158 +7,112 @@ import sys
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from typing import Dict, List
 
-from pulsar_neuron.ingest.bar_builder import IST, SESSION_START, BarBuilder
+from pulsar_neuron.ingest.bar_builder import BarBuilder, IST
 from pulsar_neuron.ingest.derive_tfs import derive_15m
 from pulsar_neuron.db.ohlcv_repo import upsert_many
 
 try:
-    from kiteconnect import KiteTicker
-except Exception:  # pragma: no cover - optional dependency
-    KiteTicker = None  # type: ignore[misc]
+    from kiteconnect import KiteTicker  # type: ignore
+except Exception:  # pragma: no cover
+    KiteTicker = None  # type: ignore
 
 
 def _load_tokens() -> Dict[str, int]:
     raw = os.getenv("KITE_TOKENS_JSON", "")
     if not raw:
         raise RuntimeError(
-            "KITE_TOKENS_JSON env missing. Example: '{\"NIFTY 50\":256265, \"NIFTY BANK\":260105}'"
+            "KITE_TOKENS_JSON not set. Example: '{\"NIFTY 50\":256265, \"NIFTY BANK\":260105}'"
         )
-    try:
-        payload = json.loads(raw)
-    except json.JSONDecodeError as exc:  # pragma: no cover - validation
-        raise RuntimeError("KITE_TOKENS_JSON must be valid JSON") from exc
-
-    return {str(symbol): int(token) for symbol, token in payload.items()}
+    m = json.loads(raw)
+    return {k: int(v) for k, v in m.items()}
 
 
-def _minutes_since_session_start(ts_ist: datetime) -> int:
-    session_start = ts_ist.replace(
-        hour=SESSION_START.hour,
-        minute=SESSION_START.minute,
-        second=0,
-        microsecond=0,
-    )
-    return int((ts_ist - session_start).total_seconds() // 60)
-
-
-def main() -> None:
+def main():
     api_key = os.getenv("KITE_API_KEY")
     access_token = os.getenv("KITE_ACCESS_TOKEN")
-
     if not api_key or not access_token:
-        raise RuntimeError("Set KITE_API_KEY and KITE_ACCESS_TOKEN in env")
-
+        raise RuntimeError("Set KITE_API_KEY and KITE_ACCESS_TOKEN.")
     if KiteTicker is None:
-        raise RuntimeError("kiteconnect not installed. Install with 'pip install kiteconnect'")
+        raise RuntimeError("kiteconnect is not installed. pip install kiteconnect")
 
     token_map = _load_tokens()
-    if not token_map:
-        raise RuntimeError("No instruments provided in KITE_TOKENS_JSON")
-
     symbols = list(token_map.keys())
     tokens = list(token_map.values())
-    token_to_symbol = {token: symbol for symbol, token in token_map.items()}
 
     builder = BarBuilder(symbols=symbols, tf="5m")
     lock = threading.Lock()
-    recent_5m: Dict[str, List[dict]] = {symbol: [] for symbol in symbols}
-    last_15m_upsert: Dict[str, datetime] = {symbol: datetime.min.replace(tzinfo=IST) for symbol in symbols}
+    recent_5m_buffer: Dict[str, List[dict]] = {s: [] for s in symbols}
 
-    def on_ticks(_ws, ticks: List[Dict]) -> None:  # pragma: no cover - network callback
-        now = datetime.now(timezone.utc)
+    def on_ticks(ws, ticks):
         with lock:
-            for tick in ticks:
-                token = int(tick.get("instrument_token", 0))
-                symbol = token_to_symbol.get(token)
+            for t in ticks:
+                token = t.get("instrument_token")
+                price = float(t.get("last_price") or t.get("last_trade_price") or 0.0)
+                if not token or not price:
+                    continue
+                symbol = next((s for s, tok in token_map.items() if tok == token), None)
                 if not symbol:
                     continue
+                vol = int(t.get("volume", 0))
+                builder.on_tick(symbol, price, vol=vol, ts=datetime.now(timezone.utc))
 
-                price = float(tick.get("last_price") or tick.get("last_trade_price") or 0.0)
-                if not price:
-                    continue
-
-                volume: Optional[int]
-                if "volume" in tick and tick["volume"] is not None:
-                    volume = int(tick["volume"])
-                else:
-                    volume = None
-
-                builder.on_tick(symbol=symbol, price=price, vol=volume, ts=now)
-
-    def on_connect(ws, _response) -> None:  # pragma: no cover - network callback
+    def on_connect(ws, response):
         ws.subscribe(tokens)
         ws.set_mode(ws.MODE_FULL, tokens)
 
-    def on_close(_ws, code, reason) -> None:  # pragma: no cover - network callback
-        print(f"WebSocket closed: {code} {reason}", file=sys.stderr)
+    def on_close(ws, code, reason):
+        print(f"[live_bars] socket closed: {code} {reason}", file=sys.stderr)
 
-    ticker = KiteTicker(api_key, access_token)
-    ticker.on_ticks = on_ticks
-    ticker.on_connect = on_connect
-    ticker.on_close = on_close
+    kws = KiteTicker(api_key, access_token)
+    kws.on_ticks = on_ticks
+    kws.on_connect = on_connect
+    kws.on_close = on_close
 
-    stop_event = threading.Event()
+    stop = threading.Event()
 
-    def flusher() -> None:
-        while not stop_event.is_set():
-            time.sleep(1)
+    def flusher():
+        while not stop.is_set():
+            time.sleep(1.0)
             with lock:
                 completed = builder.maybe_close()
-
             if not completed:
                 continue
 
+            for b in completed:
+                s = b["symbol"]
+                recent_5m_buffer[s].append(b)
+                if len(recent_5m_buffer[s]) > 12:
+                    recent_5m_buffer[s] = recent_5m_buffer[s][-12:]
+
             upsert_many(completed)
 
-            for bar in completed:
-                symbol = bar["symbol"]
-                recent_5m[symbol].append(bar)
-                if len(recent_5m[symbol]) > 12:
-                    recent_5m[symbol] = recent_5m[symbol][-12:]
-
             derived_rows: List[dict] = []
-            for symbol, buf in recent_5m.items():
-                if len(buf) < 3:
-                    continue
-
-                last_three = buf[-3:]
-                last_ts: datetime = last_three[-1]["ts_ist"].astimezone(IST)
-                minutes_since = _minutes_since_session_start(last_ts)
-                if minutes_since % 15 != 0:
-                    continue
-
-                if last_three[-1]["ts_ist"] <= last_15m_upsert[symbol]:
-                    continue
-
-                derived = derive_15m(last_three)
-                if not derived:
-                    continue
-
-                derived_rows.extend(derived)
-                last_15m_upsert[symbol] = last_three[-1]["ts_ist"]
-
+            for s, buf in recent_5m_buffer.items():
+                if len(buf) >= 3:
+                    last_three = buf[-3:]
+                    derived_rows.extend(derive_15m(last_three))
             if derived_rows:
                 upsert_many(derived_rows)
 
-    thread = threading.Thread(target=flusher, daemon=True)
-    thread.start()
+    t = threading.Thread(target=flusher, daemon=True)
+    t.start()
 
-    def shutdown(*_args) -> None:
-        stop_event.set()
+    def _shutdown(*_):
+        stop.set()
         try:
-            ticker.stop()
-        except Exception:  # pragma: no cover - defensive
+            kws.stop()
+        except Exception:
             pass
-        thread.join(timeout=2)
-        print("Shutdown complete.")
+        t.join(timeout=2.0)
+        print("[live_bars] Shutdown complete.")
         sys.exit(0)
 
-    signal.signal(signal.SIGINT, shutdown)
-    signal.signal(signal.SIGTERM, shutdown)
+    signal.signal(signal.SIGINT, _shutdown)
+    signal.signal(signal.SIGTERM, _shutdown)
 
-    ticker.connect(threaded=False)
+    kws.connect(threaded=False)
 
 
 if __name__ == "__main__":

--- a/src/pulsar_neuron/cli/run_scheduler.py
+++ b/src/pulsar_neuron/cli/run_scheduler.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+from pulsar_neuron.ingest import fut_oi_job, options_job, market_job
+from pulsar_neuron.db.fut_oi_repo import upsert_many as upsert_fut_oi
+from pulsar_neuron.db.options_repo import upsert_many as upsert_options
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def now_ist() -> datetime:
+    return datetime.now(tz=IST)
+
+
+def sleep_until(target: datetime) -> None:
+    while True:
+        now = now_ist()
+        dt = (target - now).total_seconds()
+        if dt <= 0:
+            return
+        time.sleep(min(dt, 0.5))
+
+
+def next_on_second(mod: int, offset_sec: int = 0) -> datetime:
+    """Next IST time where epoch % mod == offset_sec."""
+    now = now_ist().replace(microsecond=0)
+    epoch = int(now.timestamp())
+    add = (mod - (epoch % mod) + offset_sec) % mod
+    return now + timedelta(seconds=add)
+
+
+def main():
+    # Cadence plan:
+    # - OI every 120s @ +10s
+    # - Options every 180s @ +20s
+    # - Breadth/VIX every 300s @ +30s  (TODO persist later)
+    while True:
+        t_oi = next_on_second(120, 10)
+        t_opt = next_on_second(180, 20)
+        t_mkt = next_on_second(300, 30)
+        target = min(t_oi, t_opt, t_mkt)
+        sleep_until(target)
+        now = now_ist()
+
+        if abs((now - t_oi).total_seconds()) < 1.0:
+            rows = fut_oi_job.run(["NIFTY", "BANKNIFTY"], mode="live")
+            if rows:
+                upsert_fut_oi(rows)
+
+        if abs((now - t_opt).total_seconds()) < 1.0:
+            rows = options_job.run(["NIFTY", "BANKNIFTY"], mode="live", strikes=5)
+            if rows:
+                upsert_options(rows)
+
+        if abs((now - t_mkt).total_seconds()) < 1.0:
+            _ = market_job.run(mode="live")  # TODO: persist breadth/vix repo when ready
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/cli/watch_health.py
+++ b/src/pulsar_neuron/cli/watch_health.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from pulsar_neuron.db.ohlcv_repo import read_last_n as read_ohlcv_last
+from pulsar_neuron.db.fut_oi_repo import read_last as read_oi_last
+from pulsar_neuron.db.options_repo import read_latest_snapshot
+
+IST = ZoneInfo("Asia/Kolkata")
+
+
+def _fmt_ts(ts) -> str:
+    if isinstance(ts, datetime):
+        return ts.astimezone(IST).strftime("%H:%M:%S")
+    return str(ts)
+
+
+def main():
+    for s in ["NIFTY 50", "NIFTY BANK"]:
+        last_5m = read_ohlcv_last(s, "5m", 1)
+        last_15m = read_ohlcv_last(s, "15m", 1)
+        ts5 = _fmt_ts(last_5m[-1]["ts_ist"]) if last_5m else "-"
+        ts15 = _fmt_ts(last_15m[-1]["ts_ist"]) if last_15m else "-"
+        print(f"{s:11s}  5m:{ts5}  15m:{ts15}")
+
+    for s in ["NIFTY", "BANKNIFTY"]:
+        oi = read_oi_last(s, 1)
+        oi_ts = _fmt_ts(oi[0]["ts_ist"]) if oi else "-"
+        chain = read_latest_snapshot(s)
+        ch_ts = _fmt_ts(chain[0]["ts_ist"]) if chain else "-"
+        print(f"{s:10s}  OI:{oi_ts}  OPT:{ch_ts}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/ingest/bar_builder.py
+++ b/src/pulsar_neuron/ingest/bar_builder.py
@@ -1,9 +1,8 @@
-"""Utilities to aggregate tick data into IST-aligned OHLCV bars."""
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, time, timedelta
-from typing import Dict, List, Literal, Optional
+from typing import Dict, Optional, Literal, List
 from zoneinfo import ZoneInfo
 
 Timeframe = Literal["5m", "15m", "1d"]
@@ -14,38 +13,37 @@ SESSION_END = time(15, 30)
 
 
 def _now_ist() -> datetime:
-    """Return the current time in IST."""
     return datetime.now(tz=IST)
 
 
-def _session_bounds(ts: datetime) -> tuple[datetime, datetime]:
-    """Return the start/end datetimes of the trading session for ``ts``."""
-    base = ts.astimezone(IST)
-    start = base.replace(hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0)
-    end = base.replace(hour=SESSION_END.hour, minute=SESSION_END.minute, second=0, microsecond=0)
-    return start, end
+def _session_bounds(d: datetime) -> tuple[datetime, datetime]:
+    return (
+        d.replace(hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0),
+        d.replace(hour=SESSION_END.hour, minute=SESSION_END.minute, second=0, microsecond=0),
+    )
 
 
 def _next_5m_end(after: datetime) -> datetime:
-    """Return the next 5-minute bar end after ``after`` (inclusive)."""
-    current = after.astimezone(IST)
-    start, end = _session_bounds(current)
-
-    if current < start:
+    """Return the next 5m bar END timestamp in IST session.
+    First end is 09:20; then every 5 minutes; past 15:30 → next day 09:20.
+    """
+    d = after.astimezone(IST)
+    start, end = _session_bounds(d)
+    if d < start:
         return start + timedelta(minutes=5)
-
-    if current >= end:
-        next_day = (current + timedelta(days=1)).replace(hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0)
-        return next_day + timedelta(minutes=5)
-
-    minutes_since_start = int((current - start).total_seconds() // 60)
-    next_bucket = (minutes_since_start // 5 + 1) * 5
+    if d >= end:
+        nd = (d + timedelta(days=1)).replace(
+            hour=SESSION_START.hour, minute=SESSION_START.minute, second=0, microsecond=0
+        )
+        return nd + timedelta(minutes=5)
+    mins = int((d - start).total_seconds() // 60)
+    next_bucket = (mins // 5 + 1) * 5
     return start + timedelta(minutes=next_bucket)
 
 
 @dataclass
 class BarState:
-    ts_end: datetime
+    ts_end: datetime  # IST bar end
     o: float
     h: float
     l: float
@@ -54,80 +52,57 @@ class BarState:
 
 
 class BarBuilder:
-    """Maintain per-symbol bar state and emit completed bars on boundaries."""
+    """Tick → 5m OHLCV aggregator with strict IST bar-end semantics.
+    Feed ticks via on_tick(); call maybe_close() ~1/s; it emits completed bars.
+    """
 
     def __init__(self, symbols: List[str], tf: Timeframe = "5m"):
-        if tf != "5m":
-            raise ValueError("BarBuilder currently only supports 5m timeframe")
-
+        assert tf == "5m", "BarBuilder currently builds 5m bars only."
         self.tf = tf
-        self.state: Dict[str, Optional[BarState]] = {symbol: None for symbol in symbols}
+        self.state: Dict[str, Optional[BarState]] = {s: None for s in symbols}
 
-    def _ensure_bucket(self, symbol: str, now_ist: datetime, price: float) -> None:
-        state = self.state.get(symbol)
-        if state is not None:
-            return
+    def _ensure_bucket(self, symbol: str, now_ist: datetime, price: float):
+        st = self.state[symbol]
+        if st is None:
+            ts_end = _next_5m_end(now_ist - timedelta(milliseconds=1))
+            self.state[symbol] = BarState(
+                ts_end=ts_end, o=price, h=price, l=price, c=price, v=0
+            )
 
-        ts_end = _next_5m_end(now_ist - timedelta(milliseconds=1))
-        self.state[symbol] = BarState(ts_end=ts_end, o=price, h=price, l=price, c=price, v=0)
-
-    def on_tick(
-        self,
-        symbol: str,
-        price: float,
-        vol: Optional[int] = None,
-        ts: Optional[datetime] = None,
-    ) -> None:
+    def on_tick(self, symbol: str, price: float, vol: Optional[int] = None, ts: Optional[datetime] = None):
         now = ts.astimezone(IST) if ts else _now_ist()
         self._ensure_bucket(symbol, now, price)
-        state = self.state[symbol]
-        if state is None:
-            return
-
-        if price > state.h:
-            state.h = price
-        if price < state.l:
-            state.l = price
-        state.c = price
-
-        if vol is not None:
-            state.v += int(max(vol, 0))
-
-    def _roll_state(self, state: BarState) -> Optional[BarState]:
-        if state.ts_end.astimezone(IST).time() == SESSION_END:
-            return None
-
-        next_end = _next_5m_end(state.ts_end)
-        return BarState(ts_end=next_end, o=state.c, h=state.c, l=state.c, c=state.c, v=0)
+        st = self.state[symbol]
+        assert st is not None
+        if price > st.h:
+            st.h = price
+        if price < st.l:
+            st.l = price
+        st.c = price
+        if vol:
+            st.v += int(max(vol, 0))
 
     def maybe_close(self, now: Optional[datetime] = None) -> List[dict]:
-        current = now.astimezone(IST) if now else _now_ist()
-        completed: List[dict] = []
-
-        for symbol, state in list(self.state.items()):
-            if state is None:
+        now = now.astimezone(IST) if now else _now_ist()
+        out: List[dict] = []
+        for symbol, st in self.state.items():
+            if st is None:
                 continue
-
-            while current >= state.ts_end:
-                completed.append(
+            if now >= st.ts_end:
+                out.append(
                     {
                         "symbol": symbol,
                         "tf": self.tf,
-                        "ts_ist": state.ts_end,
-                        "o": float(state.o),
-                        "h": float(state.h),
-                        "l": float(state.l),
-                        "c": float(state.c),
-                        "v": int(state.v),
+                        "ts_ist": st.ts_end,
+                        "o": float(st.o),
+                        "h": float(st.h),
+                        "l": float(st.l),
+                        "c": float(st.c),
+                        "v": int(st.v),
                     }
                 )
-
-                next_state = self._roll_state(state)
-                self.state[symbol] = next_state
-
-                if next_state is None:
-                    break
-
-                state = next_state
-
-        return completed
+                next_end = st.ts_end + timedelta(minutes=5)
+                self.state[symbol] = BarState(
+                    ts_end=next_end, o=st.c, h=st.c, l=st.c, c=st.c, v=0
+                )
+        return out

--- a/src/pulsar_neuron/ingest/derive_tfs.py
+++ b/src/pulsar_neuron/ingest/derive_tfs.py
@@ -1,30 +1,26 @@
-"""Helpers to derive higher timeframe bars from 5-minute data."""
 from __future__ import annotations
-
-from typing import Dict, List
+from typing import List, Dict
 
 
 def derive_15m(bars_5m: List[Dict]) -> List[Dict]:
-    """Aggregate sequential 5m bars into a 15m bar."""
+    """Aggregate 3×5m → 1×15m. Input must be ascending by ts_ist."""
     out: List[Dict] = []
-    buffer: List[Dict] = []
-
-    for bar in bars_5m:
-        buffer.append(bar)
-        if len(buffer) == 3:
-            first, _, last = buffer
+    buf: List[Dict] = []
+    for b in bars_5m:
+        buf.append(b)
+        if len(buf) == 3:
+            first, mid, last = buf[0], buf[1], buf[2]
             out.append(
                 {
                     "symbol": last["symbol"],
                     "tf": "15m",
-                    "ts_ist": last["ts_ist"],
+                    "ts_ist": last["ts_ist"],  # end aligns to the third 5m
                     "o": first["o"],
-                    "h": max(b["h"] for b in buffer),
-                    "l": min(b["l"] for b in buffer),
+                    "h": max(x["h"] for x in buf),
+                    "l": min(x["l"] for x in buf),
                     "c": last["c"],
-                    "v": sum(int(b["v"]) for b in buffer),
+                    "v": sum(x["v"] for x in buf),
                 }
             )
-            buffer.clear()
-
+            buf.clear()
     return out


### PR DESCRIPTION
## Summary
- add an IST-aligned 5 minute bar builder and 15 minute derivation utilities
- implement a live KiteTicker runner that stores completed 5m and derived 15m bars
- provide a scheduler CLI for derivatives jobs and a health watcher CLI for recent timestamps

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pulsar_neuron')*

------
https://chatgpt.com/codex/tasks/task_e_68e17fab6e1083278b5e66a12c7315f2