### PR TITLE
Fix Poetry packaging configuration for pulsar_neuron

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,15 @@
 [tool.poetry]
 name = "pulsar-neuron"
 version = "0.1.0"
-description = "Pulsar Neuron — Postgres-only live market spine (indices, context, strategies)"
-authors = ["Abhay Singh <you@example.com>"]
-packages = [{ include = "pulsar_neuron", from = "src" }]
+description = "Agentic Market Intelligence and Ingestion Framework"
+authors = ["Abhay Singh <abhay@example.com>"]
+packages = [
+    { include = "pulsar_neuron", from = "src" }
+]
 
 [tool.poetry.dependencies]
-python = ">=3.11,<3.13"
-psycopg2-binary = "^2.9.10"
+python = "^3.10"
+psycopg2-binary = "^2.9"
 
 [build-system]
 requires = ["poetry-core>=1.9.0"]

--- a/src/pulsar_neuron/__init__.py
+++ b/src/pulsar_neuron/__init__.py
@@ -1,4 +1,3 @@
-"""Stub
-NOTE: Stub module. Add real logic later.
-"""
-pass
+"""Pulsar Neuron — Core AI & Market Data Engine"""
+
+__version__ = "0.1.0"

--- a/src/pulsar_neuron/config/__init__.py
+++ b/src/pulsar_neuron/config/__init__.py
@@ -1,4 +1,1 @@
-"""Stub
-NOTE: Stub module. Add real logic later.
-"""
-pass
+"""Configuration package."""

--- a/src/pulsar_neuron/db/__init__.py
+++ b/src/pulsar_neuron/db/__init__.py
@@ -1,4 +1,1 @@
-"""Stub
-NOTE: Stub module. Add real logic later.
-"""
-pass
+"""Database layer."""


### PR DESCRIPTION
## Summary
- align the Poetry project metadata with the pulsar_neuron source tree and author details
- add minimal package initializers so pulsar_neuron and its config/db subpackages are importable

## Testing
- `poetry install` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*
- `poetry lock` *(fails: offline environment cannot reach pypi.org)*
- `poetry run python -m pulsar_neuron.cli.db_init` *(fails: pulsar_neuron package not installed because Poetry install aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68e20e1fca7483278a10cac94edd64b4