### PR TITLE
Add CLI utilities for health checks and scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # PHONY targets (non-file)
 # ─────────────────────────────────────────────
 .PHONY: fmt lint type test migrate advisory \
-        run-spine run-ingestors \
+        run-spine run-ingestors token-check \
         db-migrate db-oi-mock db-options-mock db-derivs-read \
         run-live run-scheduler watch-health \
         db-init db-smoke
@@ -20,7 +20,7 @@ type:
 	@echo "🔠 type-check (stub)"
 
 test:
-	@echo "🧪 pytest (stub)"
+	PYTHONPATH=src poetry run pytest -q
 
 migrate:
 	@echo "📦 apply sql in db/migrations (stub)"
@@ -68,6 +68,10 @@ run-live:
 # Aligned scheduler (OI / Options / later breadth-vix)
 run-scheduler:
 	poetry run python -m pulsar_neuron.cli.run_scheduler
+
+# Kite token visibility
+token-check:
+	poetry run python -m pulsar_neuron.cli.check_kite_token
 
 # Health watcher (prints latest timestamps from DB)
 watch-health:

--- a/src/pulsar_neuron/cli/check_kite_token.py
+++ b/src/pulsar_neuron/cli/check_kite_token.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import time
+from pathlib import Path
+from pulsar_neuron.config.kite_auth import load_kite_creds, LOCAL_TOKEN_FILE
+
+
+def main():
+    creds = load_kite_creds()
+    ak = creds.get("api_key")
+    at = creds.get("access_token")
+    print("api_key      :", (ak[:6] + "…") if ak else None)
+    print("access_token :", (at[:6] + "…") if at else None)
+
+    p = Path(LOCAL_TOKEN_FILE)
+    if p.exists():
+        age = time.time() - p.stat().st_mtime
+        print(f"token_file   : {p} (age ~{int(age)}s)")
+    else:
+        print(f"token_file   : {p} (missing; probably using AWS Secrets)")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pulsar_neuron/cli/run_spine.py
+++ b/src/pulsar_neuron/cli/run_spine.py
@@ -1,105 +1,44 @@
-"""Offline spine runner for Pulsar Neuron."""
 from __future__ import annotations
+from pulsar_neuron.config.loader import load_config
+from pulsar_neuron.service.context_pack import build_from_db
 
-import logging
-from typing import Any, Dict
-
-from pulsar_neuron.ingest import ohlcv_job
-from pulsar_neuron.service import context_pack
-from pulsar_neuron.strategies import s_orb, s_vwap_reclaim
-
-LOGGER = logging.getLogger(__name__)
-
-
-def _configure_logging() -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    )
-
-
-def _summarize_context(ctx: Any) -> str:
-    if isinstance(ctx, dict):
-        parts = []
-        for key, value in ctx.items():
-            if isinstance(value, (int, float, str, bool)):
-                parts.append(f"{key}={value}")
-            elif value is None:
-                parts.append(f"{key}=None")
-            else:
-                parts.append(f"{key}=<{type(value).__name__}>")
-        return ", ".join(parts) if parts else "<empty>"
-    return str(ctx)
+# Import strategy "run" functions if available
+try:
+    from pulsar_neuron.strategies.s_orb import run as orb_run  # type: ignore
+except Exception:
+    orb_run = None
+try:
+    from pulsar_neuron.strategies.s_vwap_reclaim import run as vwap_run  # type: ignore
+except Exception:
+    vwap_run = None
+try:
+    from pulsar_neuron.strategies.s_trend_cont import run as trend_run  # type: ignore
+except Exception:
+    trend_run = None
 
 
-def _build_context(symbol: str, bars: Any) -> Any:
-    builder = getattr(context_pack, "build", None)
-    if callable(builder):
-        return builder(bars)
-
-    LOGGER.warning("context_pack.build missing, falling back to build_context stub")
-    fallback = getattr(context_pack, "build_context", None)
-    if callable(fallback):
-        return fallback(symbol=symbol, now_ist="mock")
-
-    raise AttributeError("context_pack does not provide build or build_context")
-
-
-def _evaluate_strategy(module: Any, ctx: Any, name: str) -> Any:
-    evaluate = getattr(module, "evaluate", None)
-    if callable(evaluate):
-        try:
-            return evaluate(ctx)
-        except Exception:  # pragma: no cover - defensive logging
-            LOGGER.exception("Strategy %s.evaluate raised an exception", name)
-            return "error"
-
-    checklist = getattr(module, "checklist", None)
-    if callable(checklist):
-        try:
-            return checklist(ctx)
-        except Exception:  # pragma: no cover - defensive logging
-            LOGGER.exception("Strategy %s.checklist raised an exception", name)
-            return "error"
-
-    LOGGER.warning("Strategy module %s has no evaluate/checklist entry point", name)
-    return "unavailable"
-
-
-def main() -> None:
-    _configure_logging()
-    print("🚀 Pulsar Neuron — Offline Spine (Mock Mode)")
-
+def _safe(f, x):
     try:
-        bars: Dict[str, Any] = ohlcv_job.run(
-            symbols=["NIFTY 50", "NIFTY BANK"],
-            tf="5m",
-            mode="mock",
-        )
-        LOGGER.info("Fetched OHLCV bars for %d symbols", len(bars))
-    except Exception as exc:  # pragma: no cover - runtime guard
-        LOGGER.exception("Failed to run OHLCV job: %s", exc)
-        return
+        return f(x) if f else None
+    except Exception as e:
+        return f"ERR:{e}"
 
-    if not bars:
-        LOGGER.warning("No bars returned from OHLCV job")
-        return
 
-    for symbol, symbol_bars in bars.items():
-        try:
-            ctx = _build_context(symbol, symbol_bars)
-            summary = _summarize_context(ctx)
-            orb_state = _evaluate_strategy(s_orb, ctx, "s_orb")
-            vwap_state = _evaluate_strategy(s_vwap_reclaim, ctx, "s_vwap_reclaim")
-        except Exception as exc:  # pragma: no cover - runtime guard
-            LOGGER.exception("Failed processing symbol %s: %s", symbol, exc)
-            continue
+def main():
+    cfg = load_config("markets.yaml")
+    tokens = cfg.get("tokens") or {}
+    symbols = list(tokens.keys())
+    if not symbols:
+        raise RuntimeError("No symbols in markets.yaml -> tokens")
 
-        print(f"\n===== {symbol} =====")
-        print(f"Context: {summary}")
-        print(f"ORB: {orb_state}")
-        print(f"VWAP Reclaim: {vwap_state}")
-        print("--------------------------")
+    ctx = build_from_db(symbols)
+    print("symbol, last_5m_ts, sma20_5m, slope_5m, orb, vwap, trend")
+    for s in symbols:
+        x = ctx.get(s, {})
+        orb = _safe(orb_run, x)
+        vwp = _safe(vwap_run, x)
+        trn = _safe(trend_run, x)
+        print(f"{s}, {x.get('last_5m_ts')}, {x.get('sma20_5m')}, {x.get('slope_5m')}, {orb}, {vwp}, {trn}")
 
 
 if __name__ == "__main__":

--- a/src/pulsar_neuron/service/context_pack.py
+++ b/src/pulsar_neuron/service/context_pack.py
@@ -1,13 +1,36 @@
-    """Context pack builder
-    NOTE: Stub module. Add real logic later.
+from __future__ import annotations
+from typing import Dict, List
+from pulsar_neuron.db.ohlcv_repo import read_last_n
+
+
+def _sma(vals: List[float], n: int) -> float:
+    if len(vals) < n:
+        return float('nan')
+    return sum(vals[-n:]) / n
+
+
+def build_from_db(symbols: List[str]) -> Dict[str, dict]:
     """
+    Minimal context pack:
+      - last 60 x 5m closes
+      - sma20 on 5m
+      - simple 5-bar slope on 5m
+    Extend later with vwap_rel, ORB state, OI bias, options skew.
+    """
+    ctx: Dict[str, dict] = {}
+    for s in symbols:
+        bars5 = read_last_n(s, "5m", 60)
+        bars15 = read_last_n(s, "15m", 20)
 
-def build_context(symbol: str, now_ist: str) -> dict:
-    """Return compact facts + freshness + ok."""
-    return {
-        "symbol": symbol,
-        "now": now_ist,
-        "ok": False,
-        "payload": {}
-    }
+        closes5 = [float(b["c"]) for b in bars5]
+        sma20 = _sma(closes5, 20) if closes5 else float('nan')
+        slope5 = (closes5[-1] - closes5[-5]) / 5 if len(closes5) >= 5 else float('nan')
 
+        ctx[s] = {
+            "last_5m_ts": bars5[-1]["ts_ist"] if bars5 else None,
+            "last_15m_ts": bars15[-1]["ts_ist"] if bars15 else None,
+            "sma20_5m": sma20,
+            "slope_5m": slope5,
+            "closes5": closes5[-10:],  # keep a tail for debugging
+        }
+    return ctx


### PR DESCRIPTION
## Summary
- add CLI utilities to inspect ingestion health and kite tokens
- build minimal context pack with SMA/slope features and wire into spine runner
- replace scheduler with threaded scaffold and expose new make targets

## Testing
- PYTHONPATH=src poetry run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e254a16e4083279bfee31a9ddceae2